### PR TITLE
fix(poll): preserve vote count on truncated game button labels

### DIFF
--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -2487,11 +2487,7 @@ def _build_settings_keyboard(
             )
         ],
         [InlineKeyboardButton(f"Vote Limit: {limit_text}", callback_data="cycle_vote_limit")],
-        [
-            InlineKeyboardButton(
-                f"Shuffle Options: {shuffle_icon}", callback_data="toggle_shuffle"
-            )
-        ],
+        [InlineKeyboardButton(f"Shuffle Options: {shuffle_icon}", callback_data="toggle_shuffle")],
         [
             InlineKeyboardButton(
                 f"Hide Results: {hide_results_icon}", callback_data="toggle_hide_results"
@@ -3011,9 +3007,7 @@ async def render_poll_message(bot, chat_id, message_id, session, poll_id, games,
         if level > 0:
             header_text = f"--- {level} ---" if not show_count else f"--- {level} ({cat_count}) ---"
         else:
-            header_text = (
-                "--- Unrated ---" if not show_count else f"--- Unrated ({cat_count}) ---"
-            )
+            header_text = "--- Unrated ---" if not show_count else f"--- Unrated ({cat_count}) ---"
         keyboard.append(
             [InlineKeyboardButton(header_text, callback_data=f"poll_random_vote:{poll_id}:{level}")]
         )
@@ -3021,17 +3015,13 @@ async def render_poll_message(bot, chat_id, message_id, session, poll_id, games,
         current_row = []
         for g in sorted_group:
             count = vote_counts[g.id]
-            # Label: "⭐ Catan (2)" — hide count when hide_results is on
-            label = ""
-            if g.id in priority_ids:
-                label += "⭐ "
-            label += g.name
-
-            if count > 0 and not hide_results:
-                label += f" ({count})"
-
-            if len(label) > 30:
-                label = label[:27] + "..."
+            # Label: "⭐ Catan (2)" — reserve space for suffix so the count
+            # survives truncation on long names.
+            prefix = "⭐ " if g.id in priority_ids else ""
+            suffix = f" ({count})" if count > 0 and not hide_results else ""
+            max_name = 36 - len(prefix) - len(suffix)
+            name = g.name if len(g.name) <= max_name else g.name[: max_name - 1] + "…"
+            label = f"{prefix}{name}{suffix}"
             current_row.append(InlineKeyboardButton(label, callback_data=f"vote:{poll_id}:{g.id}"))
 
             if len(current_row) == 2:
@@ -3316,9 +3306,7 @@ async def _handle_poll_add(query, context: ContextTypes.DEFAULT_TYPE, poll_id: s
             current_row = []
     if current_row:
         keyboard.append(current_row)
-    keyboard.append(
-        [InlineKeyboardButton("🔙 Cancel", callback_data=f"poll_add_cancel:{poll_id}")]
-    )
+    keyboard.append([InlineKeyboardButton("🔙 Cancel", callback_data=f"poll_add_cancel:{poll_id}")])
 
     with contextlib.suppress(telegram.error.BadRequest):
         await query.answer()

--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -3335,7 +3335,7 @@ async def poll_add_select_callback(update: Update, context: ContextTypes.DEFAULT
         # Just delete the picker message
         with contextlib.suppress(telegram.error.BadRequest):
             await query.answer()
-            await query.message.delete()
+            await query.message.delete()  # type: ignore[attr-defined]
         return
 
     if len(parts) < 3:
@@ -3383,7 +3383,7 @@ async def poll_add_select_callback(update: Update, context: ContextTypes.DEFAULT
 
         # Delete the picker message
         with contextlib.suppress(telegram.error.BadRequest):
-            await query.message.delete()
+            await query.message.delete()  # type: ignore[attr-defined]
 
         # Refresh the poll
         valid_games, priority_ids = await get_session_valid_games(session, chat_id)

--- a/src/bot/main.py
+++ b/src/bot/main.py
@@ -103,9 +103,7 @@ def main():
     app.add_handler(
         CallbackQueryHandler(toggle_allow_adding_callback, pattern=r"^toggle_allow_adding$")
     )
-    app.add_handler(
-        CallbackQueryHandler(custom_poll_action_callback, pattern=r"^poll_add:")
-    )
+    app.add_handler(CallbackQueryHandler(custom_poll_action_callback, pattern=r"^poll_add:"))
     app.add_handler(CallbackQueryHandler(poll_add_select_callback, pattern=r"^poll_add_select:"))
     app.add_handler(CallbackQueryHandler(poll_add_select_callback, pattern=r"^poll_add_cancel:"))
     app.add_handler(CallbackQueryHandler(manage_collection_callback, pattern="^manage:"))

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -167,9 +167,7 @@ class PollAddedGame(Base):
     """Track games manually added to a poll by participants (allow_adding_options)."""
 
     __tablename__ = "poll_added_games"
-    __table_args__ = (
-        UniqueConstraint("poll_id", "game_id", name="uq_poll_added_game"),
-    )
+    __table_args__ = (UniqueConstraint("poll_id", "game_id", name="uq_poll_added_game"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     poll_id: Mapped[str] = mapped_column(ForeignKey("game_night_polls.poll_id"), index=True)

--- a/tests/test_custom_poll.py
+++ b/tests/test_custom_poll.py
@@ -1591,8 +1591,12 @@ async def test_custom_poll_add_game_duplicate_prevented(mock_update, mock_contex
 
         g1 = Game(id=1, name="Catan", min_players=2, max_players=4, playing_time=60, complexity=2.0)
         g_extra = Game(
-            id=extra_game_id, name="Extra", min_players=1,
-            max_players=2, playing_time=30, complexity=1.0,
+            id=extra_game_id,
+            name="Extra",
+            min_players=1,
+            max_players=2,
+            playing_time=30,
+            complexity=1.0,
         )
         session.add_all([g1, g_extra])
         await session.flush()
@@ -1671,8 +1675,11 @@ async def test_custom_poll_hide_results_hides_category_votes(mock_update, mock_c
 
         # Add category votes
         v1 = PollVote(
-            poll_id=poll_id, user_id=111, vote_type=VoteType.CATEGORY,
-            category_level=3, user_name="User1",
+            poll_id=poll_id,
+            user_id=111,
+            vote_type=VoteType.CATEGORY,
+            category_level=3,
+            user_name="User1",
         )
         session.add(v1)
         await session.commit()
@@ -1836,8 +1843,12 @@ async def test_poll_added_games_cascade_deleted(mock_update, mock_context):
 
         g1 = Game(id=1, name="Game1", min_players=2, max_players=4, playing_time=60, complexity=2.0)
         g2 = Game(
-            id=99, name="Added", min_players=2, max_players=4,
-            playing_time=60, complexity=1.5,
+            id=99,
+            name="Added",
+            min_players=2,
+            max_players=4,
+            playing_time=60,
+            complexity=1.5,
         )
         session.add_all([g1, g2])
         await session.flush()


### PR DESCRIPTION
## Summary
- Reserve space for the star prefix and `(count)` suffix before truncating long game names on custom-poll buttons, and raise the label budget from 30 to 36 characters, so voters on long-title games can actually see the count they just cast.
- Apply ruff formatting to three files (`src/bot/main.py`, `src/core/models.py`, `tests/test_custom_poll.py`) that were left unformatted after the poll API migration merge, so `ruff format --check` passes on this branch.

## Test plan
- [x] `uv run pytest` — 144 passed
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [ ] Manually create a custom poll with a long game name (e.g. "Twilight Imperium: Prophecy of Kings"), cast a vote, and confirm the `(1)` appears on the button after truncation.