### PR TITLE
fix: unblock Cloud Run webhook startup (tornado + asyncpg URL params)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "lxml>=6.0.2",
     "python-dotenv>=1.2.1",
     "python-telegram-bot[job-queue]>=22.5",
+    "tornado>=6.5.4",
     "sqlalchemy[asyncio]>=2.0.36",
     "asyncpg>=0.30.0",
     "aiosqlite>=0.20.0",

--- a/src/core/db.py
+++ b/src/core/db.py
@@ -14,7 +14,9 @@ def resolve_database_url(url: str | None = None) -> str:
     raw = url or os.getenv("DATABASE_URL", "sqlite+aiosqlite:///game_night.db")
     if raw.startswith("postgres://"):
         raw = raw.replace("postgres://", "postgresql+asyncpg://", 1)
-    elif raw.startswith("postgresql://") and "asyncpg" not in raw and "+" not in raw.split("://")[0]:
+    elif (
+        raw.startswith("postgresql://") and "asyncpg" not in raw and "+" not in raw.split("://")[0]
+    ):
         raw = raw.replace("postgresql://", "postgresql+asyncpg://", 1)
     # Rewrite libpq-only query params that asyncpg doesn't understand, so
     # Neon-style URLs copied from their dashboard work unchanged:

--- a/src/core/db.py
+++ b/src/core/db.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from collections.abc import AsyncGenerator
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -12,9 +13,23 @@ logger = logging.getLogger(__name__)
 def resolve_database_url(url: str | None = None) -> str:
     raw = url or os.getenv("DATABASE_URL", "sqlite+aiosqlite:///game_night.db")
     if raw.startswith("postgres://"):
-        return raw.replace("postgres://", "postgresql+asyncpg://", 1)
-    if raw.startswith("postgresql://") and "asyncpg" not in raw and "+" not in raw.split("://")[0]:
-        return raw.replace("postgresql://", "postgresql+asyncpg://", 1)
+        raw = raw.replace("postgres://", "postgresql+asyncpg://", 1)
+    elif raw.startswith("postgresql://") and "asyncpg" not in raw and "+" not in raw.split("://")[0]:
+        raw = raw.replace("postgresql://", "postgresql+asyncpg://", 1)
+    # Rewrite libpq-only query params that asyncpg doesn't understand, so
+    # Neon-style URLs copied from their dashboard work unchanged:
+    #   - sslmode=X -> ssl=X (same values accepted)
+    #   - channel_binding=X: dropped; no asyncpg equivalent, TLS still enforced
+    #     by ssl=require
+    if "+asyncpg" in raw:
+        parts = urlsplit(raw)
+        if parts.query:
+            params = [
+                ("ssl", v) if k == "sslmode" else (k, v)
+                for k, v in parse_qsl(parts.query, keep_blank_values=True)
+                if k != "channel_binding"
+            ]
+            raw = urlunsplit(parts._replace(query=urlencode(params)))
     return raw
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -233,6 +233,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-telegram-bot", extra = ["job-queue"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "tornado" },
 ]
 
 [package.dev-dependencies]
@@ -259,6 +260,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-telegram-bot", extras = ["job-queue"], specifier = ">=22.5" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
+    { name = "tornado", specifier = ">=6.5.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -974,6 +976,23 @@ wheels = [
 [package.optional-dependencies]
 asyncio = [
     { name = "greenlet" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/f1/3173dfa4a18db4a9b03e5d55325559dab51ee653763bb8745a75af491286/tornado-6.5.5.tar.gz", hash = "sha256:192b8f3ea91bd7f1f50c06955416ed76c6b72f96779b962f07f911b91e8d30e9", size = 516006, upload-time = "2026-03-10T21:31:02.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:487dc9cc380e29f58c7ab88f9e27cdeef04b2140862e5076a66fb6bb68bb1bfa", size = 445983, upload-time = "2026-03-10T21:30:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5e/7625b76cd10f98f1516c36ce0346de62061156352353ef2da44e5c21523c/tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:65a7f1d46d4bb41df1ac99f5fcb685fb25c7e61613742d5108b010975a9a6521", size = 444246, upload-time = "2026-03-10T21:30:46.571Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e74c92e8e65086b338fd56333fb9a68b9f6f2fe7ad532645a290a464bcf46be5", size = 447229, upload-time = "2026-03-10T21:30:48.273Z" },
+    { url = "https://files.pythonhosted.org/packages/34/01/74e034a30ef59afb4097ef8659515e96a39d910b712a89af76f5e4e1f93c/tornado-6.5.5-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:435319e9e340276428bbdb4e7fa732c2d399386d1de5686cb331ec8eee754f07", size = 448192, upload-time = "2026-03-10T21:30:51.22Z" },
+    { url = "https://files.pythonhosted.org/packages/be/00/fe9e02c5a96429fce1a1d15a517f5d8444f9c412e0bb9eadfbe3b0fc55bf/tornado-6.5.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3f54aa540bdbfee7b9eb268ead60e7d199de5021facd276819c193c0fb28ea4e", size = 448039, upload-time = "2026-03-10T21:30:53.52Z" },
+    { url = "https://files.pythonhosted.org/packages/82/9e/656ee4cec0398b1d18d0f1eb6372c41c6b889722641d84948351ae19556d/tornado-6.5.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36abed1754faeb80fbd6e64db2758091e1320f6bba74a4cf8c09cd18ccce8aca", size = 447445, upload-time = "2026-03-10T21:30:55.541Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/76/4921c00511f88af86a33de770d64141170f1cfd9c00311aea689949e274e/tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7", size = 448582, upload-time = "2026-03-10T21:30:57.142Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/23/f6c6112a04d28eed765e374435fb1a9198f73e1ec4b4024184f21faeb1ad/tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b", size = 448990, upload-time = "2026-03-10T21:30:58.857Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c8/876602cbc96469911f0939f703453c1157b0c826ecb05bdd32e023397d4e/tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6", size = 448016, upload-time = "2026-03-10T21:31:00.43Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two small fixes needed for the initial Cloud Run deployment to come up:

- **tornado dep**: `run_webhook` needs tornado, but `python-telegram-bot[job-queue]` doesn't pull it in. Container was crashing at startup with `to use start_webhook, PTB must be installed via pip install ...` and failing Cloud Run's health check. Matching the `bgg-search-telegram-bot` pattern of declaring `tornado` directly.
- **asyncpg URL params**: Neon's default connection string (copied from their dashboard) uses libpq's `sslmode=` and `channel_binding=`, which asyncpg rejects. Normalize in `resolve_database_url`: rewrite `sslmode` → `ssl`, drop `channel_binding` (no asyncpg equivalent; TLS still enforced). Migration step was failing with `connect() got an unexpected keyword argument 'sslmode'`.

## Test plan

- [ ] Merge, run Release, then Deploy — verify Cloud Run revision goes ready
- [ ] Hit the bot in Telegram to confirm webhook delivery works end-to-end