### PR TITLE
chore: meet BGG API attribution requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ uv run ruff check .
 uv run mypy .
 ```
 
+## Attribution
+
+Game data is sourced from [BoardGameGeek](https://boardgamegeek.com/) via their [XML API](https://boardgamegeek.com/wiki/page/BGG_XML_API2). Usage is subject to BGG's [API terms of use](https://boardgamegeek.com/xmlapi/termsofuse). "BoardGameGeek" is a trademark of BoardGameGeek, LLC.
+
 ## License
 
 MIT

--- a/scripts/sync_bot_config.py
+++ b/scripts/sync_bot_config.py
@@ -62,7 +62,8 @@ BOT_DESCRIPTION: str | None = (
     "• 🗳️ **Smart Voting:** I'll find games that fit your player count and generate a poll.\n"
     "• 👥 **Fair Play:** Filters games based on who is actually playing.\n\n"
     "👇 **Get Started:**\n"
-    "Add me to your group chat and use /gamenight to begin!"
+    "Add me to your group chat and use /gamenight to begin!\n\n"
+    "Powered by BoardGameGeek"
 )
 
 # Bot short description - shown on the bot's profile page (max 120 chars)

--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -209,7 +209,8 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "• /addgame `<name>` - Search BGG and add game\n"
         "• /manage - Toggle game availability (⬜→🌟→❌)\n"
         "• /help - Show all available commands\n\n"
-        "_Add me to a group chat for the best experience!_"
+        "_Add me to a group chat for the best experience!_\n\n"
+        "Powered by BoardGameGeek"
     )
 
     if os.path.exists(banner_path):
@@ -243,7 +244,8 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "• **Allow Suggestions**: Let players add games mid-poll\n\n"
         "**Other:**\n"
         "• /help - Show this message\n"
-        "• /start - Show welcome message"
+        "• /start - Show welcome message\n\n"
+        "Powered by BoardGameGeek"
     )
     await update.message.reply_text(help_text, parse_mode="Markdown")
 
@@ -1217,6 +1219,7 @@ async def add_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
             # Extract data for reply before session closes
             g_name = game.name
+            g_id = game.id
             g_min = game.min_players
             g_max = game.max_players
             g_comp = game.complexity
@@ -1227,8 +1230,11 @@ async def add_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
             f"📊 **Details from BGG:**\n"
             f"• Players: {g_min}-{g_max}\n"
             f"• Complexity: {g_comp:.2f}/5\n"
-            f"• Play time: {g_time} min",
+            f"• Play time: {g_time} min\n\n"
+            f"[View on BoardGameGeek](https://boardgamegeek.com/boardgame/{g_id})\n"
+            "Powered by BoardGameGeek",
             parse_mode="Markdown",
+            disable_web_page_preview=True,
         )
 
     except Exception as e:
@@ -2229,11 +2235,13 @@ async def _render_detail_view(query: CallbackQuery, user_id: int, game_id: int) 
     )
     await query.edit_message_text(
         f"⚙️ **{game.name}**\n"
-        f"Players: {game.min_players}–{game.max_players} (BGG default)\n"
+        f"Players: {game.min_players}–{game.max_players} "
+        f"([BGG default](https://boardgamegeek.com/boardgame/{game.id}))\n"
         f"{override_text}\n\n"
         "Set a custom max player count below:",
         reply_markup=InlineKeyboardMarkup(keyboard),
         parse_mode="Markdown",
+        disable_web_page_preview=True,
     )
 
 

--- a/src/core/bgg.py
+++ b/src/core/bgg.py
@@ -13,16 +13,13 @@ BGG_API_TOKEN = os.getenv("BGG_API_TOKEN")
 
 
 class BGGClient:
+    # BGG XML API2 — terms of use: https://boardgamegeek.com/xmlapi/termsofuse
     BASE_URL = "https://boardgamegeek.com/xmlapi2"
+    USER_AGENT = "GameNightDeciderBot (+https://github.com/JCaet/game-night-decider)"
 
     def _get_headers(self) -> dict:
         """Get headers for BGG API requests."""
-        headers = {
-            "User-Agent": (
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-            )
-        }
+        headers = {"User-Agent": self.USER_AGENT}
         if BGG_API_TOKEN:
             headers["Authorization"] = f"Bearer {BGG_API_TOKEN}"
         return headers

--- a/uv.lock
+++ b/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "game-night-decider"
-version = "1.0.2"
+version = "1.0.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

BGG's XML API [terms of use](https://boardgamegeek.com/xmlapi/termsofuse) require user-visible attribution and links back to boardgamegeek.com — bgg-search already does this, gnd didn't.

- Add "Powered by BoardGameGeek" to `/start`, `/help`, `/addgame` confirmation, and the bot profile description (`BOT_DESCRIPTION`).
- Link game names to `boardgamegeek.com/boardgame/<id>` from `/addgame` and the `/manage` detail view.
- Replace the spoofed Chrome User-Agent in `src/core/bgg.py` with an identifying UA — BGG community guidance is to self-identify rather than impersonate a browser.
- README + `bgg.py` get an attribution/terms-of-use note.

`uv.lock`: resync against the pyproject version bump that landed on main.

## Not doing (yet)
- **Poll message attribution** — skipped per discussion (too noisy on every vote).
- **BGG logo** — not bundled. Adding one needs written permission from BGG; leaving text-only for now.
- **Caching/retention review** — gnd persists collections locally; BGG's stance on this needs manual verification against the live wiki.

## Test plan
- [ ] `/start`, `/help`, `/addgame <name>`, `/manage` show attribution and working BGG links
- [ ] `scripts/sync_bot_config.py` run reflects new `BOT_DESCRIPTION`
- [ ] No regression in unit tests (`uv run pytest`)