### PR TITLE
chore: tighten CI/CD permissions and pin drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -27,6 +29,8 @@ jobs:
 
   type-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -44,6 +48,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.12", "3.13"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
 
       - name: Google Auth
         id: auth
@@ -58,7 +59,7 @@ jobs:
           token_format: 'access_token'
 
       - name: Docker Login to Artifact Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: us-central1-docker.pkg.dev
           username: oauth2accesstoken

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    concurrency: release
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
     outputs:
       released: ${{ steps.detect.outputs.released }}
       version: ${{ steps.semantic.outputs.version }}


### PR DESCRIPTION
## Summary

Low-risk, mechanical tightening from the recent CI/CD security review:

- **ci.yml** — explicit `contents: read` on every job. Lockdown of the default `GITHUB_TOKEN` scope; belt-and-suspenders for fork-PR safety if secrets are ever introduced to CI jobs later.
- **deploy.yml** — `persist-credentials: false` on checkout. The job never pushes, so the token being persisted in `.git/config` served no purpose.
- **deploy.yml** — bump \`docker/login-action\` v3 → v4 to match \`bgg-search\`.
- **release.yml** — scope the release concurrency group to the ref (`release-${{ github.ref }}`) instead of the global string \`release\`, so a \`workflow_dispatch\` during a push-triggered release doesn't cancel one of them.

## Not doing

- \`id-token: write\` on the release workflow stays. The caller's \`GITHUB_TOKEN\` permissions cap the reusable deploy workflow's permissions, so dropping it here would break WIF auth in the called deploy job.

## Test plan
- [ ] CI checks (lint / type-check / test) still pass on this PR
- [ ] After merge, next Release run succeeds and the triggered Deploy run still authenticates to GCP