### PR TITLE
fix(ci): remove broken event_name gate that silently skipped deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,6 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
## Summary
- Removes the job-level `if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'` guard in `deploy.yml`.
- Inside a reusable workflow, `github.event_name` resolves to the **caller's** triggering event (e.g. `push`), never `workflow_call`, so this condition evaluated false and the deploy job was silently skipped on `push → release → deploy`.
- Gating is already correctly handled in the caller at `release.yml:62-65` (requires `needs.release.result == 'success'` and either `workflow_dispatch` or `released == 'true'`), so the inner guard was redundant as well as broken.

## Context
- Release run [24837537996](https://github.com/JCaet/game-night-decider/actions/runs/24837537996) tagged `v1.1.0` successfully but the inner `deploy` job ran for 0s with conclusion `skipped`.
- `v1.1.0` was never shipped to Cloud Run. A one-time manual deploy will be needed after this merges: `gh workflow run deploy.yml -f ref=v1.1.0`.

## Test plan
- [ ] Merge and land a trivial `feat:` / `fix:` commit on `main`, confirm the release → deploy chain runs end-to-end and Cloud Run receives the new image.
- [ ] Confirm `workflow_dispatch` manual runs of `deploy.yml` still execute (unchanged path).