### PR TITLE
fix(bot-config): trim short description to fit 120-char Telegram limit

### DIFF
--- a/scripts/sync_bot_config.py
+++ b/scripts/sync_bot_config.py
@@ -69,7 +69,7 @@ BOT_DESCRIPTION: str | None = (
 # Bot short description - shown on the bot's profile page (max 120 chars)
 # Leave None to keep current
 BOT_SHORT_DESCRIPTION: str | None = (
-    "Your board game night companion! 🎲 Syncs BGG collections and helps groups vote on what to play.\n\nPowered by BoardGameGeek"
+    "Your game night companion! 🎲 Syncs BGG collections and helps groups vote on what to play.\n\nPowered by BoardGameGeek"
 )
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- `BOT_SHORT_DESCRIPTION` was 121 code points after the `Powered by BoardGameGeek` attribution was appended in 5a96b4e, which exceeds Telegram's 120-char limit for `setShortDescription` and caused deploy to fail with `Bot_Sharetext_invalid`.
- Drops `board ` from the opening phrase to bring the string to 115 chars while preserving the BGG attribution (kept per BGG XML API terms of use).

## Test plan
- [ ] `uv run python scripts/sync_bot_config.py` completes without `Bot_Sharetext_invalid`
- [ ] Confirm the short description renders correctly on the bot's Telegram profile