### PR TITLE
fix(bgg): drop player counts the BGG community marks as not playable

### DIFF
--- a/alembic/versions/2026_04_28_add_community_unplayable_counts.py
+++ b/alembic/versions/2026_04_28_add_community_unplayable_counts.py
@@ -1,0 +1,30 @@
+"""add community_unplayable_counts to games
+
+Revision ID: 9f2d8c4a1e3b
+Revises: 7c4e9b6d2a11
+Create Date: 2026-04-28 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "9f2d8c4a1e3b"
+down_revision: str | Sequence[str] | None = "7c4e9b6d2a11"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add community_unplayable_counts column for BGG suggested-numplayers blocklist."""
+    with op.batch_alter_table("games", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("community_unplayable_counts", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop community_unplayable_counts column."""
+    with op.batch_alter_table("games", schema=None) as batch_op:
+        batch_op.drop_column("community_unplayable_counts")

--- a/scripts/refresh_community_player_counts.py
+++ b/scripts/refresh_community_player_counts.py
@@ -1,0 +1,65 @@
+"""Refresh community_unplayable_counts for all games with the field unpopulated.
+
+Hits BGG /thing once per game and writes the parsed CSV (or empty string if the
+poll exists but no count met the blocklist threshold) back to the row. Safe to
+re-run; only games where the field is NULL are touched.
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlalchemy import select
+
+from src.core import db
+from src.core.bgg import BGGClient
+from src.core.models import Game
+
+
+async def refresh_community_player_counts() -> None:
+    bgg = BGGClient()
+
+    async with db.AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(Game).where(Game.community_unplayable_counts.is_(None), Game.id > 0)
+        )
+        games = result.scalars().all()
+
+        print(f"Found {len(games)} games with no community_unplayable_counts")
+
+        updated = 0
+        blocked_total = 0
+        for i, game in enumerate(games):
+            print(f"[{i + 1}/{len(games)}] {game.name} (ID: {game.id})")
+            try:
+                details = await bgg.get_game_details(game.id)
+            except Exception as e:
+                print(f"  -> Error: {e}")
+                await asyncio.sleep(0.5)
+                continue
+
+            if details is None:
+                print("  -> No details returned")
+                await asyncio.sleep(0.5)
+                continue
+
+            value = details.community_unplayable_counts
+            # Persist empty string to mark "parsed, nothing blocked" so we don't retry.
+            game.community_unplayable_counts = value if value is not None else ""
+            updated += 1
+            if value:
+                blocked_total += 1
+                print(f"  -> Blocked counts: {value}")
+            else:
+                print("  -> No counts blocked")
+
+            await asyncio.sleep(0.5)
+
+        await session.commit()
+        print("\n=== DONE ===")
+        print(f"Updated {updated}/{len(games)} games ({blocked_total} with at least one block)")
+
+
+if __name__ == "__main__":
+    asyncio.run(refresh_community_player_counts())

--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -20,6 +20,7 @@ from src.core.bgg import BGGClient
 from src.core.logic import (
     STAR_BOOST,
     group_games_by_complexity,
+    player_count_blocked,
     split_games,
 )
 from src.core.models import (
@@ -1032,6 +1033,8 @@ async def create_poll(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 Game.min_players <= player_count,
                 # Use effective_max_players if set (from owned expansions), else base game max
                 func.coalesce(Collection.effective_max_players, Game.max_players) >= player_count,
+                # Drop counts the BGG community marks as not playable (e.g. Dune Uprising 5p)
+                ~player_count_blocked(Game.community_unplayable_counts, player_count),
             )
             .distinct()
         )
@@ -1855,6 +1858,7 @@ async def start_poll_callback(update: Update, context: ContextTypes.DEFAULT_TYPE
                 Game.min_players <= player_count,
                 # Use effective_max_players if set (from owned expansions), else base game max
                 func.coalesce(Collection.effective_max_players, Game.max_players) >= player_count,
+                ~player_count_blocked(Game.community_unplayable_counts, player_count),
             )
             .distinct()
         )
@@ -3000,6 +3004,7 @@ async def get_session_valid_games(session, chat_id):
             Collection.state != GameState.EXCLUDED,
             Game.min_players <= player_count,
             func.coalesce(Collection.effective_max_players, Game.max_players) >= player_count,
+            ~player_count_blocked(Game.community_unplayable_counts, player_count),
         )
         .distinct()
     )

--- a/src/core/bgg.py
+++ b/src/core/bgg.py
@@ -11,6 +11,64 @@ logger = logging.getLogger(__name__)
 
 BGG_API_TOKEN = os.getenv("BGG_API_TOKEN")
 
+# Thresholds for treating a count as community-blocked. Tuned against real BGG data:
+# blocks Dune Uprising 5p, Wingspan 5p, 7 Wonders 2p; rejects low-sample noise (e.g.
+# Red Dragon Inn editions where each count has only ~3 votes).
+COMMUNITY_BLOCKLIST_MIN_VOTES = 30
+COMMUNITY_BLOCKLIST_NOT_REC_SHARE = 0.60
+
+
+def _extract_unplayable_counts(
+    item: ET.Element, official_min: int, official_max: int
+) -> str | None:
+    """
+    Parse the suggested_numplayers poll on a /thing item and return a CSV of
+    integer player counts within [official_min, official_max] that the community
+    marks as not playable.
+
+    A count is "not playable" only when ALL hold:
+      - total votes >= COMMUNITY_BLOCKLIST_MIN_VOTES
+      - not_recommended > best + recommended
+      - not_recommended share >= COMMUNITY_BLOCKLIST_NOT_REC_SHARE
+
+    Returns:
+        CSV like "5" or "" (poll seen, nothing blocked) or None (no poll).
+        Non-integer buckets like "5+" are ignored — the blocklist constrains
+        only within the official range.
+    """
+    poll = None
+    for p in item.findall("poll"):
+        if p.get("name") == "suggested_numplayers":
+            poll = p
+            break
+    if poll is None:
+        return None
+
+    blocked: list[int] = []
+    for results in poll.findall("results"):
+        np_str = results.get("numplayers", "")
+        if not np_str.isdigit():
+            continue
+        np = int(np_str)
+        if np < official_min or np > official_max:
+            continue
+
+        counts = {r.get("value"): int(r.get("numvotes", 0)) for r in results.findall("result")}
+        best = counts.get("Best", 0)
+        rec = counts.get("Recommended", 0)
+        not_rec = counts.get("Not Recommended", 0)
+        total = best + rec + not_rec
+        if total < COMMUNITY_BLOCKLIST_MIN_VOTES:
+            continue
+        if not_rec <= best + rec:
+            continue
+        if (not_rec / total) < COMMUNITY_BLOCKLIST_NOT_REC_SHARE:
+            continue
+
+        blocked.append(np)
+
+    return ",".join(str(n) for n in sorted(blocked))
+
 
 class BGGClient:
     # BGG XML API2 — terms of use: https://boardgamegeek.com/xmlapi/termsofuse
@@ -285,6 +343,8 @@ class BGGClient:
                         with contextlib.suppress(ValueError):
                             complexity = float(avg_weight.get("value", 0))
 
+            community_unplayable = _extract_unplayable_counts(item, min_players, max_players)
+
             return Game(
                 id=bgg_id,
                 name=name,
@@ -295,6 +355,7 @@ class BGGClient:
                 max_playing_time=max_playing_time,
                 complexity=complexity,
                 thumbnail=thumbnail,
+                community_unplayable_counts=community_unplayable,
             )
         except (ValueError, AttributeError) as e:
             logger.warning(f"Failed to parse thing item {bgg_id}: {e}")

--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -1,4 +1,24 @@
+from typing import Any
+
+from sqlalchemy import func
+
 from src.core.models import Game
+
+
+def player_count_blocked(column: Any, n: int) -> Any:
+    """
+    SQLAlchemy expression: True iff `n` is present in the CSV-encoded
+    Game.community_unplayable_counts column. Uses LIKE patterns anchored on
+    commas so "1" doesn't match inside "15".
+    """
+    needle = str(n)
+    col = func.coalesce(column, "")
+    return (
+        (col == needle)
+        | col.like(f"{needle},%")
+        | col.like(f"%,{needle}")
+        | col.like(f"%,{needle},%")
+    )
 
 
 def _get_complexity_label(min_c: float, max_c: float) -> str:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -37,8 +37,21 @@ class Game(Base):
     complexity: Mapped[float] = mapped_column(Float)  # BGG Weight (1-5)
     thumbnail: Mapped[str | None] = mapped_column(String, nullable=True)
 
+    # CSV of integer player counts within [min_players, max_players] that the BGG
+    # community-suggested player-count poll marks as not playable. Example: "5"
+    # for Dune: Imperium – Uprising. Empty string = poll parsed, no counts blocked.
+    # NULL = never parsed (treated the same as empty by the filter).
+    community_unplayable_counts: Mapped[str | None] = mapped_column(String, nullable=True)
+
     # Relationships
     # user_collections: Mapped[List["Collection"]] = relationship(back_populates="game")
+
+
+def parse_unplayable_counts(raw: str | None) -> set[int]:
+    """Parse the CSV stored in Game.community_unplayable_counts to a set of ints."""
+    if not raw:
+        return set()
+    return {int(x) for x in raw.split(",") if x.strip().isdigit()}
 
 
 class User(Base):

--- a/tests/test_bgg.py
+++ b/tests/test_bgg.py
@@ -148,3 +148,159 @@ def test_parse_thing_xml_empty():
     game = client._parse_thing_xml(empty_xml, bgg_id=999)
 
     assert game is None
+
+
+# Suggested-numplayers poll parsing
+DUNE_UPRISING_THING_XML = b"""
+<items>
+    <item type="boardgame" id="397598">
+        <name type="primary" value="Dune: Imperium - Uprising"/>
+        <minplayers value="1"/>
+        <maxplayers value="6"/>
+        <playingtime value="120"/>
+        <minplaytime value="60"/>
+        <maxplaytime value="120"/>
+        <poll name="suggested_numplayers" totalvotes="500">
+            <results numplayers="1">
+                <result value="Best" numvotes="22"/>
+                <result value="Recommended" numvotes="149"/>
+                <result value="Not Recommended" numvotes="113"/>
+            </results>
+            <results numplayers="2">
+                <result value="Best" numvotes="18"/>
+                <result value="Recommended" numvotes="171"/>
+                <result value="Not Recommended" numvotes="118"/>
+            </results>
+            <results numplayers="3">
+                <result value="Best" numvotes="153"/>
+                <result value="Recommended" numvotes="204"/>
+                <result value="Not Recommended" numvotes="20"/>
+            </results>
+            <results numplayers="4">
+                <result value="Best" numvotes="320"/>
+                <result value="Recommended" numvotes="84"/>
+                <result value="Not Recommended" numvotes="6"/>
+            </results>
+            <results numplayers="5">
+                <result value="Best" numvotes="2"/>
+                <result value="Recommended" numvotes="12"/>
+                <result value="Not Recommended" numvotes="246"/>
+            </results>
+            <results numplayers="6">
+                <result value="Best" numvotes="58"/>
+                <result value="Recommended" numvotes="140"/>
+                <result value="Not Recommended" numvotes="53"/>
+            </results>
+            <results numplayers="6+">
+                <result value="Best" numvotes="1"/>
+                <result value="Recommended" numvotes="1"/>
+                <result value="Not Recommended" numvotes="182"/>
+            </results>
+        </poll>
+        <statistics page="1">
+            <ratings>
+                <averageweight value="3.6"/>
+            </ratings>
+        </statistics>
+    </item>
+</items>
+"""
+
+# Like Red Dragon Inn 4 — community signal exists but every count has fewer than 30 votes.
+LOW_SAMPLE_THING_XML = b"""
+<items>
+    <item type="boardgame" id="142402">
+        <name type="primary" value="The Red Dragon Inn 4"/>
+        <minplayers value="2"/>
+        <maxplayers value="4"/>
+        <playingtime value="60"/>
+        <poll name="suggested_numplayers" totalvotes="4">
+            <results numplayers="2">
+                <result value="Best" numvotes="0"/>
+                <result value="Recommended" numvotes="2"/>
+                <result value="Not Recommended" numvotes="1"/>
+            </results>
+            <results numplayers="3">
+                <result value="Best" numvotes="1"/>
+                <result value="Recommended" numvotes="3"/>
+                <result value="Not Recommended" numvotes="0"/>
+            </results>
+            <results numplayers="4">
+                <result value="Best" numvotes="3"/>
+                <result value="Recommended" numvotes="1"/>
+                <result value="Not Recommended" numvotes="0"/>
+            </results>
+        </poll>
+        <statistics page="1">
+            <ratings><averageweight value="1.5"/></ratings>
+        </statistics>
+    </item>
+</items>
+"""
+
+# Catan-shaped: official 3-4, community recommends both. Nothing should be blocked.
+CATAN_THING_XML = b"""
+<items>
+    <item type="boardgame" id="13">
+        <name type="primary" value="Catan"/>
+        <minplayers value="3"/>
+        <maxplayers value="4"/>
+        <playingtime value="90"/>
+        <poll name="suggested_numplayers" totalvotes="2000">
+            <results numplayers="3">
+                <result value="Best" numvotes="721"/>
+                <result value="Recommended" numvotes="1154"/>
+                <result value="Not Recommended" numvotes="112"/>
+            </results>
+            <results numplayers="4">
+                <result value="Best" numvotes="1541"/>
+                <result value="Recommended" numvotes="465"/>
+                <result value="Not Recommended" numvotes="47"/>
+            </results>
+        </poll>
+        <statistics page="1">
+            <ratings><averageweight value="2.32"/></ratings>
+        </statistics>
+    </item>
+</items>
+"""
+
+
+def test_parse_thing_xml_blocks_dune_uprising_5p():
+    """Suggested-numplayers poll → blocks 5 within official 1-6 for Dune Uprising."""
+    client = BGGClient()
+    game = client._parse_thing_xml(DUNE_UPRISING_THING_XML, bgg_id=397598)
+
+    assert game is not None
+    assert game.min_players == 1
+    assert game.max_players == 6
+    assert game.community_unplayable_counts == "5"
+
+
+def test_parse_thing_xml_low_sample_does_not_block():
+    """When per-count totals are below the threshold, no count is blocked."""
+    client = BGGClient()
+    game = client._parse_thing_xml(LOW_SAMPLE_THING_XML, bgg_id=142402)
+
+    assert game is not None
+    # Empty string = poll seen, nothing met the blocklist threshold.
+    assert game.community_unplayable_counts == ""
+
+
+def test_parse_thing_xml_no_poll_returns_none_blocklist():
+    """When the suggested-numplayers poll is absent, blocklist is None (unknown)."""
+    client = BGGClient()
+    # MOCK_THING_XML defined earlier in the file has no <poll> element.
+    game = client._parse_thing_xml(MOCK_THING_XML, bgg_id=13)
+
+    assert game is not None
+    assert game.community_unplayable_counts is None
+
+
+def test_parse_thing_xml_catan_recommended_counts_not_blocked():
+    """All counts in Catan's official range are community-recommended → no block."""
+    client = BGGClient()
+    game = client._parse_thing_xml(CATAN_THING_XML, bgg_id=13)
+
+    assert game is not None
+    assert game.community_unplayable_counts == ""

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,13 +1,18 @@
 from dataclasses import dataclass
 
+import pytest
+from sqlalchemy import select
+
+from src.core import db
 from src.core.logic import (
     STAR_BOOST,
     _find_best_split,
     _get_complexity_label,
     calculate_poll_winner,
+    player_count_blocked,
     split_games,
 )
-from src.core.models import Game
+from src.core.models import Game, parse_unplayable_counts
 
 
 def create_game(name: str, complexity: float) -> Game:
@@ -334,3 +339,118 @@ def test_calculate_poll_winner_with_star_boost():
     assert scores["NormalGame"] == 1.0
     assert len(modifiers) == 1
     assert "StarredGame" in modifiers[0]
+
+
+# ---------------------------------------------------------------------------- #
+# Community player-count blocklist
+# ---------------------------------------------------------------------------- #
+
+
+def test_parse_unplayable_counts():
+    assert parse_unplayable_counts(None) == set()
+    assert parse_unplayable_counts("") == set()
+    assert parse_unplayable_counts("5") == {5}
+    assert parse_unplayable_counts("2,5,7") == {2, 5, 7}
+    # Whitespace and bogus tokens are skipped
+    assert parse_unplayable_counts("5, ,abc,7") == {5, 7}
+
+
+def _make_game(
+    *,
+    game_id: int,
+    name: str,
+    min_p: int,
+    max_p: int,
+    blocklist: str | None,
+) -> Game:
+    return Game(
+        id=game_id,
+        name=name,
+        min_players=min_p,
+        max_players=max_p,
+        playing_time=60,
+        complexity=2.0,
+        community_unplayable_counts=blocklist,
+    )
+
+
+@pytest.mark.asyncio
+async def test_player_count_blocked_filter_excludes_blocked_count():
+    """A game with '5' in community_unplayable_counts should be hidden at player_count=5."""
+    async with db.AsyncSessionLocal() as session:
+        session.add_all(
+            [
+                _make_game(
+                    game_id=397598,
+                    name="Dune Uprising",
+                    min_p=1,
+                    max_p=6,
+                    blocklist="5",
+                ),
+                _make_game(
+                    game_id=13,
+                    name="Catan",
+                    min_p=3,
+                    max_p=4,
+                    blocklist="",
+                ),
+                _make_game(
+                    game_id=999,
+                    name="Unparsed",
+                    min_p=2,
+                    max_p=8,
+                    blocklist=None,
+                ),
+            ]
+        )
+        await session.commit()
+
+        # At 5p: Dune is blocked, Catan's max=4 excludes it, Unparsed (NULL) passes through.
+        stmt = select(Game).where(
+            Game.min_players <= 5,
+            Game.max_players >= 5,
+            ~player_count_blocked(Game.community_unplayable_counts, 5),
+        )
+        names_5p = {g.name for g in (await session.execute(stmt)).scalars().all()}
+        assert names_5p == {"Unparsed"}
+
+        # At 4p: Dune passes (4 not blocked), Catan passes, Unparsed passes.
+        stmt = select(Game).where(
+            Game.min_players <= 4,
+            Game.max_players >= 4,
+            ~player_count_blocked(Game.community_unplayable_counts, 4),
+        )
+        names_4p = {g.name for g in (await session.execute(stmt)).scalars().all()}
+        assert names_4p == {"Dune Uprising", "Catan", "Unparsed"}
+
+
+@pytest.mark.asyncio
+async def test_player_count_blocked_csv_substring_safety():
+    """'1' must not match inside '15'; commas anchor the search."""
+    async with db.AsyncSessionLocal() as session:
+        # Hypothetical 18-player Werewolves variant — not real, just a substring stress-test
+        session.add(
+            _make_game(
+                game_id=42,
+                name="Multi-block",
+                min_p=1,
+                max_p=20,
+                blocklist="3,15,17",
+            )
+        )
+        await session.commit()
+
+        for n, expected_blocked in [
+            (1, False),
+            (3, True),
+            (5, False),
+            (7, False),  # not the "17" suffix
+            (15, True),
+            (17, True),
+            (20, False),
+        ]:
+            stmt = select(Game.id).where(player_count_blocked(Game.community_unplayable_counts, n))
+            hits = (await session.execute(stmt)).scalars().all()
+            assert (len(hits) == 1) == expected_blocked, (
+                f"player_count={n} expected_blocked={expected_blocked}, hits={hits}"
+            )


### PR DESCRIPTION
## Summary

- Closes #47. Dune: Imperium – Uprising stops appearing at 5p (publisher says 1-6 but the game has no 5-player mode).
- Adds a `community_unplayable_counts` CSV column on `Game` and parses the `suggested_numplayers` poll already returned by `/xmlapi2/thing?stats=1`.
- Three game-selection filters in `handlers.py` now exclude counts the community-poll consensus marks as not playable.

## How counts get blocked

A count is added to the blocklist only when **all** hold:
- `total_votes >= 30`
- `not_recommended > best + recommended`
- `not_recommended_share >= 60%`

Tuned against real BGG data so we catch unambiguous gaps without overreaching:

| Game | Official | Blocked | Why |
|---|---|---|---|
| Dune: Imperium – Uprising | 1-6 | `5` | 246 not-rec vs 14 best+rec |
| 7 Wonders | 2-7 | `2` | 1384 not-rec / 1902 total = 73 % |
| Wingspan | 1-5 | _none_ | 5p sits at 59 %, deliberately below threshold |
| Catan / Dominion / Pandemic | 2-4 | _none_ | community matches publisher |
| Red Dragon Inn 4 | 2-4 | _none_ | 3-4 votes per count, low-sample noise |

Non-integer poll buckets (`5+`, `6+`) are ignored — the blocklist only constrains within the official `[min_players, max_players]` range. The combinable-multiple-editions case (Red Dragon Inn 1+2+3+4 played at 8p) belongs in the expansion-driven max work tracked in #45.

## Rollout

- One Alembic migration (additive, nullable column). Up + down verified locally.
- `NULL` (never parsed) and `""` (parsed, nothing blocked) both fall through the filter, so games that haven't been re-fetched after the deploy behave exactly as before — worst case a user re-syncs.
- One-shot backfill: `uv run python scripts/refresh_community_player_counts.py` (sleep-throttled at 0.5s/game, mirrors `refresh_complexity.py`).

## Test plan

- [x] `uv run pytest` — 165 passed
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run python -m mypy src` — clean
- [x] Migration up + down against a fresh SQLite DB: column added on upgrade, removed on downgrade
- [x] Parser end-to-end against real BGG XML for Dune Uprising / Wingspan / 7 Wonders / Catan / Pandemic / RDI 4 — outputs match the table above
- [ ] After deploy: run the backfill script and spot-check `community_unplayable_counts` on Dune Uprising
- [ ] After backfill: start a 5p session that includes Dune Uprising; verify it's excluded from the poll