### PR TITLE
fix(bgg): preserve publisher's official max in community blocklist

### DIFF
--- a/src/core/bgg.py
+++ b/src/core/bgg.py
@@ -23,13 +23,17 @@ def _extract_unplayable_counts(
 ) -> str | None:
     """
     Parse the suggested_numplayers poll on a /thing item and return a CSV of
-    integer player counts within [official_min, official_max] that the community
+    integer player counts within [official_min, official_max) that the community
     marks as not playable.
 
     A count is "not playable" only when ALL hold:
       - total votes >= COMMUNITY_BLOCKLIST_MIN_VOTES
       - not_recommended > best + recommended
       - not_recommended share >= COMMUNITY_BLOCKLIST_NOT_REC_SHARE
+
+    The publisher's max player count is never blocked: community polls there are
+    quality opinions about a supported mode (e.g. Deep Regrets 5p at 73.8 % NotRec),
+    not "this mode doesn't exist" signals like Dune Uprising 5p.
 
     Returns:
         CSV like "5" or "" (poll seen, nothing blocked) or None (no poll).
@@ -50,7 +54,7 @@ def _extract_unplayable_counts(
         if not np_str.isdigit():
             continue
         np = int(np_str)
-        if np < official_min or np > official_max:
+        if np < official_min or np >= official_max:
             continue
 
         counts = {r.get("value"): int(r.get("numvotes", 0)) for r in results.findall("result")}

--- a/src/core/bgg.py
+++ b/src/core/bgg.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 BGG_API_TOKEN = os.getenv("BGG_API_TOKEN")
 
 # Thresholds for treating a count as community-blocked. Tuned against real BGG data:
-# blocks Dune Uprising 5p, Wingspan 5p, 7 Wonders 2p; rejects low-sample noise (e.g.
-# Red Dragon Inn editions where each count has only ~3 votes).
+# blocks Dune Uprising 5p and 7 Wonders 2p; rejects low-sample noise (e.g. Red
+# Dragon Inn editions where each count has only ~3 votes).
 COMMUNITY_BLOCKLIST_MIN_VOTES = 30
 COMMUNITY_BLOCKLIST_NOT_REC_SHARE = 0.60
 
@@ -23,17 +23,21 @@ def _extract_unplayable_counts(
 ) -> str | None:
     """
     Parse the suggested_numplayers poll on a /thing item and return a CSV of
-    integer player counts within [official_min, official_max) that the community
-    marks as not playable.
+    integer player counts within [official_min, official_max] that the community
+    marks as not playable AND worse than the publisher's official max.
 
-    A count is "not playable" only when ALL hold:
+    A count `n` is blocked only when ALL hold:
       - total votes >= COMMUNITY_BLOCKLIST_MIN_VOTES
       - not_recommended > best + recommended
       - not_recommended share >= COMMUNITY_BLOCKLIST_NOT_REC_SHARE
+      - not_recommended share strictly greater than the share at official_max
 
-    The publisher's max player count is never blocked: community polls there are
-    quality opinions about a supported mode (e.g. Deep Regrets 5p at 73.8 % NotRec),
-    not "this mode doesn't exist" signals like Dune Uprising 5p.
+    The max-share comparison preserves monotonicity: we never hide a mode whose
+    community sentiment is at least as good as the publisher's max we already
+    keep. Catches "this mode doesn't exist" gaps inside the range (Dune Uprising
+    5p, 7 Wonders 2p) without dropping max-shaped quality opinions (Deep Regrets
+    5p) or strictly-better-than-max modes (Massive Darkness 2: Hellscape 5p,
+    where the community rates 5p better than the publisher's max of 6p).
 
     Returns:
         CSV like "5" or "" (poll seen, nothing blocked) or None (no poll).
@@ -48,13 +52,29 @@ def _extract_unplayable_counts(
     if poll is None:
         return None
 
+    # Find NotRec share at official_max. If the max bucket is missing or has no
+    # votes, default to 1.0 so nothing in-range can exceed it (safe default —
+    # we'd rather show the game than over-block on incomplete poll data).
+    max_share = 1.0
+    for results in poll.findall("results"):
+        np_str = results.get("numplayers", "")
+        if not np_str.isdigit() or int(np_str) != official_max:
+            continue
+        counts = {r.get("value"): int(r.get("numvotes", 0)) for r in results.findall("result")}
+        total = (
+            counts.get("Best", 0) + counts.get("Recommended", 0) + counts.get("Not Recommended", 0)
+        )
+        if total > 0:
+            max_share = counts.get("Not Recommended", 0) / total
+        break
+
     blocked: list[int] = []
     for results in poll.findall("results"):
         np_str = results.get("numplayers", "")
         if not np_str.isdigit():
             continue
         np = int(np_str)
-        if np < official_min or np >= official_max:
+        if np < official_min or np > official_max:
             continue
 
         counts = {r.get("value"): int(r.get("numvotes", 0)) for r in results.findall("result")}
@@ -66,7 +86,11 @@ def _extract_unplayable_counts(
             continue
         if not_rec <= best + rec:
             continue
-        if (not_rec / total) < COMMUNITY_BLOCKLIST_NOT_REC_SHARE:
+        share = not_rec / total
+        if share < COMMUNITY_BLOCKLIST_NOT_REC_SHARE:
+            continue
+        # Never drop a mode at least as good as the publisher's max.
+        if share <= max_share:
             continue
 
         blocked.append(np)

--- a/tests/test_bgg.py
+++ b/tests/test_bgg.py
@@ -304,3 +304,66 @@ def test_parse_thing_xml_catan_recommended_counts_not_blocked():
 
     assert game is not None
     assert game.community_unplayable_counts == ""
+
+
+# Deep Regrets-shaped: community votes the publisher's max as not playable
+# (1-5, 5p at 73.8% NotRec). Per issue #55, the official max is treated as a
+# supported mode regardless of community sentiment.
+DEEP_REGRETS_THING_XML = b"""
+<items>
+    <item type="boardgame" id="397931">
+        <name type="primary" value="Deep Regrets"/>
+        <minplayers value="1"/>
+        <maxplayers value="5"/>
+        <playingtime value="90"/>
+        <poll name="suggested_numplayers" totalvotes="107">
+            <results numplayers="1">
+                <result value="Best" numvotes="5"/>
+                <result value="Recommended" numvotes="29"/>
+                <result value="Not Recommended" numvotes="21"/>
+            </results>
+            <results numplayers="2">
+                <result value="Best" numvotes="28"/>
+                <result value="Recommended" numvotes="38"/>
+                <result value="Not Recommended" numvotes="12"/>
+            </results>
+            <results numplayers="3">
+                <result value="Best" numvotes="51"/>
+                <result value="Recommended" numvotes="21"/>
+                <result value="Not Recommended" numvotes="5"/>
+            </results>
+            <results numplayers="4">
+                <result value="Best" numvotes="16"/>
+                <result value="Recommended" numvotes="31"/>
+                <result value="Not Recommended" numvotes="27"/>
+            </results>
+            <results numplayers="5">
+                <result value="Best" numvotes="3"/>
+                <result value="Recommended" numvotes="14"/>
+                <result value="Not Recommended" numvotes="48"/>
+            </results>
+            <results numplayers="5+">
+                <result value="Best" numvotes="0"/>
+                <result value="Recommended" numvotes="0"/>
+                <result value="Not Recommended" numvotes="46"/>
+            </results>
+        </poll>
+        <statistics page="1">
+            <ratings><averageweight value="2.5"/></ratings>
+        </statistics>
+    </item>
+</items>
+"""
+
+
+def test_parse_thing_xml_does_not_block_official_max():
+    """Even when the community-poll consensus marks the official max as not playable,
+    the max is preserved as a supported mode (issue #55: Deep Regrets 5p)."""
+    client = BGGClient()
+    game = client._parse_thing_xml(DEEP_REGRETS_THING_XML, bgg_id=397931)
+
+    assert game is not None
+    assert game.min_players == 1
+    assert game.max_players == 5
+    # 5p meets the threshold (73.8% NotRec, 65 votes) but is also the official max.
+    assert game.community_unplayable_counts == ""

--- a/tests/test_bgg.py
+++ b/tests/test_bgg.py
@@ -357,13 +357,84 @@ DEEP_REGRETS_THING_XML = b"""
 
 
 def test_parse_thing_xml_does_not_block_official_max():
-    """Even when the community-poll consensus marks the official max as not playable,
-    the max is preserved as a supported mode (issue #55: Deep Regrets 5p)."""
+    """The max sets the bar: a count is only blocked if it's strictly worse than
+    the publisher's official max. Deep Regrets max=5 has the highest NotRec share
+    in its range, so nothing is blocked (issue #55)."""
     client = BGGClient()
     game = client._parse_thing_xml(DEEP_REGRETS_THING_XML, bgg_id=397931)
 
     assert game is not None
     assert game.min_players == 1
     assert game.max_players == 5
-    # 5p meets the threshold (73.8% NotRec, 65 votes) but is also the official max.
+    # 5p meets the absolute threshold (73.8% NotRec, 65 votes) AND is the max,
+    # so its share is the bar nothing else exceeds → empty blocklist.
+    assert game.community_unplayable_counts == ""
+
+
+# Massive Darkness 2: Hellscape — official 1-6, community votes 5p at 69.6% NotRec
+# and 6p (max) at 83.3%. Under a naive "skip max" rule we'd expose the worse 6p
+# while hiding the better 5p. The "strictly worse than max" rule keeps both.
+HELLSCAPE_THING_XML = b"""
+<items>
+    <item type="boardgame" id="315610">
+        <name type="primary" value="Massive Darkness 2: Hellscape"/>
+        <minplayers value="1"/>
+        <maxplayers value="6"/>
+        <playingtime value="120"/>
+        <poll name="suggested_numplayers" totalvotes="90">
+            <results numplayers="1">
+                <result value="Best" numvotes="23"/>
+                <result value="Recommended" numvotes="51"/>
+                <result value="Not Recommended" numvotes="16"/>
+            </results>
+            <results numplayers="2">
+                <result value="Best" numvotes="37"/>
+                <result value="Recommended" numvotes="49"/>
+                <result value="Not Recommended" numvotes="4"/>
+            </results>
+            <results numplayers="3">
+                <result value="Best" numvotes="59"/>
+                <result value="Recommended" numvotes="25"/>
+                <result value="Not Recommended" numvotes="5"/>
+            </results>
+            <results numplayers="4">
+                <result value="Best" numvotes="21"/>
+                <result value="Recommended" numvotes="42"/>
+                <result value="Not Recommended" numvotes="18"/>
+            </results>
+            <results numplayers="5">
+                <result value="Best" numvotes="0"/>
+                <result value="Recommended" numvotes="24"/>
+                <result value="Not Recommended" numvotes="55"/>
+            </results>
+            <results numplayers="6">
+                <result value="Best" numvotes="0"/>
+                <result value="Recommended" numvotes="13"/>
+                <result value="Not Recommended" numvotes="65"/>
+            </results>
+            <results numplayers="6+">
+                <result value="Best" numvotes="0"/>
+                <result value="Recommended" numvotes="0"/>
+                <result value="Not Recommended" numvotes="57"/>
+            </results>
+        </poll>
+        <statistics page="1">
+            <ratings><averageweight value="2.5"/></ratings>
+        </statistics>
+    </item>
+</items>
+"""
+
+
+def test_parse_thing_xml_does_not_block_count_better_than_max():
+    """A count whose NotRec share is *better* than the official max must never be
+    blocked, even if it crosses the absolute threshold. Hellscape 5p (69.6% NotRec)
+    is better than 6p max (83.3% NotRec) — both stay; the table decides."""
+    client = BGGClient()
+    game = client._parse_thing_xml(HELLSCAPE_THING_XML, bgg_id=315610)
+
+    assert game is not None
+    assert game.min_players == 1
+    assert game.max_players == 6
+    # 5p crosses 60% NotRec but sits below 6p's 83.3%, so it's not blocked.
     assert game.community_unplayable_counts == ""

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from src.core import db
 from src.core.logic import (
@@ -12,7 +12,7 @@ from src.core.logic import (
     player_count_blocked,
     split_games,
 )
-from src.core.models import Game, parse_unplayable_counts
+from src.core.models import Collection, Game, GameState, User, parse_unplayable_counts
 
 
 def create_game(name: str, complexity: float) -> Game:
@@ -454,3 +454,103 @@ async def test_player_count_blocked_csv_substring_safety():
             assert (len(hits) == 1) == expected_blocked, (
                 f"player_count={n} expected_blocked={expected_blocked}, hits={hits}"
             )
+
+
+@pytest.mark.asyncio
+async def test_manage_override_interacts_correctly_with_community_blocklist():
+    """Mirror the create_poll filter: Collection.effective_max_players (set via
+    /manage) extends the playable range upward; the community blocklist still
+    drops counts within the official range that the parser flagged."""
+    user_id = 111
+    async with db.AsyncSessionLocal() as session:
+        session.add(User(telegram_id=user_id, telegram_name="Tester"))
+
+        # Dune Uprising-shaped: official 1-6, community blocks 5p (a non-max count).
+        session.add(
+            _make_game(
+                game_id=397598,
+                name="Dune Uprising",
+                min_p=1,
+                max_p=6,
+                blocklist="5",
+            )
+        )
+        # Deep Regrets-shaped: official 1-5, community blocks NOTHING under the
+        # new "max is sacred" rule (issue #55), so blocklist is empty.
+        session.add(
+            _make_game(
+                game_id=397931,
+                name="Deep Regrets",
+                min_p=1,
+                max_p=5,
+                blocklist="",
+            )
+        )
+        await session.flush()
+
+        # User has both in their collection. Dune gets a manual /manage override
+        # bumping its effective max to 8 (homebrew variant). Deep Regrets is left
+        # untouched — default state, no override.
+        session.add(
+            Collection(
+                user_id=user_id,
+                game_id=397598,
+                state=GameState.INCLUDED,
+                effective_max_players=8,
+                is_manual_player_override=True,
+            )
+        )
+        session.add(
+            Collection(
+                user_id=user_id,
+                game_id=397931,
+                state=GameState.INCLUDED,
+            )
+        )
+        await session.commit()
+
+        # Mirror the exact filter shape from handlers.py:create_poll.
+        def _query(player_count: int):
+            return (
+                select(Game.name)
+                .join(Collection, Collection.game_id == Game.id)
+                .where(
+                    Collection.user_id == user_id,
+                    Collection.state != GameState.EXCLUDED,
+                    Game.min_players <= player_count,
+                    func.coalesce(Collection.effective_max_players, Game.max_players)
+                    >= player_count,
+                    ~player_count_blocked(Game.community_unplayable_counts, player_count),
+                )
+            )
+
+        # 5p: Deep Regrets shows (max not blocked under new rule); Dune is dropped
+        # by the community blocklist even though the manual override extends to 8.
+        names_5p = set((await session.execute(_query(5))).scalars().all())
+        assert names_5p == {"Deep Regrets"}, (
+            "Deep Regrets must appear at its official max of 5p; "
+            "Dune's 5p block must still apply despite the /manage override extending max to 8."
+        )
+
+        # 6p: Deep Regrets out of range; Dune passes (6p not blocked, max=6 anyway).
+        names_6p = set((await session.execute(_query(6))).scalars().all())
+        assert names_6p == {"Dune Uprising"}
+
+        # 8p: only Dune, only via manual override. Confirms /manage extension works.
+        names_8p = set((await session.execute(_query(8))).scalars().all())
+        assert names_8p == {"Dune Uprising"}
+
+        # 9p: nothing — manual override capped at 8.
+        names_9p = set((await session.execute(_query(9))).scalars().all())
+        assert names_9p == set()
+
+        # User then EXCLUDES Dune via /manage (state cycle → EXCLUDED).
+        await session.execute(
+            Collection.__table__.update()
+            .where(Collection.user_id == user_id, Collection.game_id == 397598)
+            .values(state=GameState.EXCLUDED)
+        )
+        await session.commit()
+
+        names_6p_after = set((await session.execute(_query(6))).scalars().all())
+        assert names_6p_after == set(), "EXCLUDED state from /manage must hide the game."


### PR DESCRIPTION
## Summary

- Closes #55. Deep Regrets (1-5) was being silently dropped from 5p polls because the BGG community-suggested-numplayers poll votes 5p at 73.8 % "Not Recommended" — a quality opinion about a publisher-shipped mode, not a "this mode doesn't exist" gap.
- Massive Darkness 2: Hellscape (1-6, surfaced during review) revealed why a naive "skip max" rule is wrong: 5p sits at 69.6 % NotRec, 6p (max) at 83.3 %, so skipping max would expose the strictly worse mode while hiding the better one.

## The rule

A count `n` within `[official_min, official_max]` is community-blocked iff:

1. `total_votes >= 30`
2. `not_recommended > best + recommended`
3. `not_recommended_share >= 60 %`
4. `not_recommended_share` **strictly greater than** `not_recommended_share` at `official_max`

The max-share comparison preserves monotonicity: we never hide a mode whose community sentiment is at least as good as the publisher's max we already keep. Max itself drops out naturally (its share fails the strict inequality against itself).

## Re-verified live against BGG

| Game | Official | Max NotRec | Old block | New block |
|---|---|---:|---|---|
| Dune: Imperium – Uprising | 1-6 | 21.1 % | `5` | `5` |
| Wingspan | 1-5 | 58.9 % | _none_ | _none_ |
| 7 Wonders | 2-7 | 16.7 % | `2` | `2` |
| Catan / Pandemic / Dominion | 2-4 / 2-4 / 2-4 | low | _none_ | _none_ |
| Red Dragon Inn 4 | 2-4 | (low-sample) | _none_ | _none_ |
| **Deep Regrets** | **1-5** | **73.8 %** | **`5`** | **_none_** |
| **Massive Darkness 2: Hellscape** | **1-6** | **83.3 %** | **`5,6`** | **_none_** |

Every previous block survives; the two max-shaped quality opinions (Deep Regrets, Hellscape) pass through.

## Test plan

- [x] `uv run pytest` — 168 passed
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run python -m mypy src` — clean
- [x] BGG-parser tests with Dune Uprising, RDI4 (low-sample), Catan, Deep Regrets (max-shaped), Hellscape (worse-than-max) XML fixtures — `community_unplayable_counts` matches the table.
- [x] `/manage` interaction test mirrors the real `create_poll` filter (Game ⨝ Collection, `coalesce(effective_max_players, max_players)`, `~player_count_blocked`). Covers: blocklist still applies under a manual override, manual override still extends to 8p, hard cap at 9p, and `/manage`-EXCLUDED hides the game.
- [ ] After deploy: re-run the backfill script. Confirm Deep Regrets flips from `"5"` to `""`, Hellscape flips from `"5,6"` to `""`, Dune Uprising still has `"5"`.
- [ ] After backfill: start a 5p session including Deep Regrets and a 6p session including Hellscape; confirm both appear in the poll.