### PR TITLE
fix(poll): exclude leaver's votes from active poll tally

### DIFF
--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -2986,6 +2986,17 @@ async def custom_poll_vote_callback(update: Update, context: ContextTypes.DEFAUL
             )
 
 
+async def get_active_member_ids(session, chat_id) -> set[int]:
+    """Return user_ids of players currently in the lobby.
+
+    Used to suspend votes cast by users who have since left the session: the
+    rows stay in the DB so they auto-resume if the user rejoins, but they are
+    excluded from tallies and winner calculation while the voter is absent.
+    """
+    stmt = select(SessionPlayer.user_id).where(SessionPlayer.session_id == chat_id)
+    return set((await session.execute(stmt)).scalars().all())
+
+
 async def get_session_valid_games(session, chat_id):
     """Helper to re-fetch valid games for a session."""
     players_stmt = select(SessionPlayer).where(SessionPlayer.session_id == chat_id)
@@ -3039,9 +3050,13 @@ async def render_poll_message(bot, chat_id, message_id, session, poll_id, games,
     # Include user-added games (from allow_adding_options)
     games = await _merge_added_games(session, poll_id, games)
 
-    # Fetch all votes for this poll
+    # Fetch all votes for this poll, then drop votes from users who have left
+    # the lobby. Rows stay in the DB (so a rejoin auto-resumes them) but are
+    # excluded from every tally below.
     votes_stmt = select(PollVote).where(PollVote.poll_id == poll_id)
-    all_votes = (await session.execute(votes_stmt)).scalars().all()
+    raw_votes = (await session.execute(votes_stmt)).scalars().all()
+    active_member_ids = await get_active_member_ids(session, chat_id)
+    all_votes = [v for v in raw_votes if v.user_id in active_member_ids]
 
     # Aggregate votes - separate game votes from category votes
     vote_counts = {g.id: 0 for g in games}

--- a/src/core/poll_service.py
+++ b/src/core/poll_service.py
@@ -21,6 +21,7 @@ from src.core.models import (
     GameState,
     PollVote,
     Session,
+    SessionPlayer,
     VoteLimit,
     VoteType,
 )
@@ -291,8 +292,13 @@ class PollService:
         Returns:
             Tuple of (winner_names, scores_dict, modifiers_log)
         """
-        # Fetch all votes
+        # Fetch all votes, then drop votes from users who left the lobby —
+        # they should not influence the winner. Rows are kept in the DB so a
+        # rejoin would auto-resume them, but no rejoin can happen after close.
         all_votes = await PollService.get_votes_for_poll(session, poll_id)
+        member_stmt = select(SessionPlayer.user_id).where(SessionPlayer.session_id == chat_id)
+        active_member_ids = set((await session.execute(member_stmt)).scalars().all())
+        all_votes = [v for v in all_votes if v.user_id in active_member_ids]
 
         # Resolve category votes to actual games
         resolved_votes = PollService.resolve_category_votes(all_votes, valid_games)

--- a/tests/test_poll_edge_cases.py
+++ b/tests/test_poll_edge_cases.py
@@ -165,6 +165,8 @@ async def test_render_anonymous_poll(mock_update, mock_context):
             Session(chat_id=chat_id, is_active=True, poll_type=PollType.CUSTOM, hide_voters=True)
         )
         session.add(User(telegram_id=222, telegram_name="SecretVoter"))
+        await session.flush()
+        session.add(SessionPlayer(session_id=chat_id, user_id=222))
 
         g1 = Game(
             id=2, name="SecretGame", min_players=1, max_players=5, complexity=3.0, playing_time=45

--- a/tests/test_vote_pruning.py
+++ b/tests/test_vote_pruning.py
@@ -602,3 +602,173 @@ async def test_no_notification_when_no_votes_suspended(mock_update, mock_context
     send_calls = mock_context.bot.send_message.call_args_list
     suspension_notification = [c for c in send_calls if "suspended" in str(c).lower()]
     assert len(suspension_notification) == 0, "Should NOT send suspension notification"
+
+
+# ============================================================================
+# Test: Leaving player's votes are excluded from the rendered poll (issue #49)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_leaver_votes_excluded_from_render(mock_update, mock_context):
+    """When a player leaves, their already-cast votes must not appear in the
+    rendered poll text or count toward totals — even when the games they
+    voted for are still valid for the remaining lobby."""
+    chat_id = 12345
+    poll_id = "poll_prune_test"
+
+    await _setup_poll_scenario(
+        chat_id=chat_id,
+        poll_id=poll_id,
+        games=[
+            {"id": 1, "name": "GameA", "min_players": 2, "max_players": 6},
+            {"id": 2, "name": "GameB", "min_players": 2, "max_players": 6},
+        ],
+        players=[111, 222, 333],
+        votes=[
+            {"user_id": 111, "game_id": 1},
+            {"user_id": 222, "game_id": 2},
+            {"user_id": 333, "game_id": 1},  # User 333 will leave
+        ],
+        vote_limit=VoteLimit.UNLIMITED,
+    )
+
+    mock_update.callback_query.from_user.id = 333
+    mock_update.callback_query.from_user.first_name = "User333"
+    mock_update.callback_query.message.chat.id = chat_id
+    mock_update.callback_query.message.message_id = 888
+
+    mock_context.bot.edit_message_text.reset_mock()
+    await leave_lobby_callback(mock_update, mock_context)
+
+    # User 333's vote must remain in the DB (suspended, will resume on rejoin)
+    async with db.AsyncSessionLocal() as session:
+        all_votes = (
+            (await session.execute(select(PollVote).where(PollVote.poll_id == poll_id)))
+            .scalars()
+            .all()
+        )
+        assert any(v.user_id == 333 for v in all_votes), (
+            "Leaver's vote must be kept in DB so it resumes on rejoin"
+        )
+
+    # Render must reflect only 2 active votes (111 and 222), not 3
+    calls = mock_context.bot.edit_message_text.call_args_list
+    assert calls, "render_poll_message should have been called on leave"
+    last_render_text = calls[-1].kwargs.get("text") or calls[-1].args[0]
+
+    assert "2 votes" in last_render_text or "2 vote" in last_render_text, (
+        f"Only the 2 remaining members' votes should be counted. Got: {last_render_text!r}"
+    )
+    # GameA was voted by both 111 (active) and 333 (left) — display must show 1, not 2
+    assert "**1** - GameA" in last_render_text, (
+        f"GameA should show 1 active vote (333's vote suspended). Got: {last_render_text!r}"
+    )
+
+
+# ============================================================================
+# Test: Leaver's votes are not counted in close_poll winner calculation
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_close_poll_ignores_leaver_votes(mock_update, mock_context):
+    """When closing a poll, votes from users who left the lobby must not
+    influence the winner."""
+    chat_id = 12345
+    poll_id = "poll_close_leaver"
+
+    await _setup_poll_scenario(
+        chat_id=chat_id,
+        poll_id=poll_id,
+        games=[
+            {"id": 1, "name": "GameA", "min_players": 2, "max_players": 6},
+            {"id": 2, "name": "GameB", "min_players": 2, "max_players": 6},
+        ],
+        players=[111, 222, 333],
+        votes=[
+            # Without filtering, GameA wins 2-1; once 333 leaves, GameB wins 1-1
+            # ... actually 1-1 is a tie. Let's tilt GameB.
+            {"user_id": 111, "game_id": 1},
+            {"user_id": 333, "game_id": 1},  # 333 leaves -> this vote should NOT count
+            {"user_id": 222, "game_id": 2},
+            {"user_id": 222, "game_id": 1},  # makes GameA tie if 333 stayed
+        ],
+        vote_limit=VoteLimit.UNLIMITED,
+    )
+
+    # 333 leaves before the poll closes
+    mock_update.callback_query.from_user.id = 333
+    mock_update.callback_query.from_user.first_name = "User333"
+    mock_update.callback_query.message.chat.id = chat_id
+    mock_update.callback_query.message.message_id = 888
+    await leave_lobby_callback(mock_update, mock_context)
+
+    async with db.AsyncSessionLocal() as session:
+        from src.bot.handlers import get_session_valid_games
+
+        valid_games, priority_ids = await get_session_valid_games(session, chat_id)
+        winners, scores, _ = await PollService.close_poll(
+            session, poll_id, chat_id, valid_games, priority_ids
+        )
+
+    # Active votes after 333 leaves: 111->A, 222->A, 222->B  → A wins 2-1.
+    # But 333's suspended vote on A should NOT push A to 3.
+    # The crucial check: scores must reflect only active-member votes.
+    assert scores.get("GameA", 0) == 2, (
+        f"GameA should have 2 active votes (333's vote excluded). Got scores: {scores}"
+    )
+    assert scores.get("GameB", 0) == 1, f"GameB should have 1 vote. Got scores: {scores}"
+    assert winners == ["GameA"], (
+        f"GameA wins 2-1 with leaver's vote excluded. Got winners: {winners}"
+    )
+
+
+# ============================================================================
+# Test: Leave-then-rejoin restores the leaver's votes
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_votes_restored_after_player_leaves_then_rejoins(mock_update, mock_context):
+    """A leaver's votes are suspended (kept in DB), so if they rejoin the
+    same lobby their votes resume counting automatically."""
+    chat_id = 12345
+    poll_id = "poll_prune_test"
+
+    await _setup_poll_scenario(
+        chat_id=chat_id,
+        poll_id=poll_id,
+        games=[
+            {"id": 1, "name": "GameA", "min_players": 2, "max_players": 6},
+        ],
+        players=[111, 222, 333],
+        votes=[
+            {"user_id": 333, "game_id": 1},
+        ],
+        vote_limit=VoteLimit.UNLIMITED,
+    )
+
+    # 333 leaves -> vote suspended
+    mock_update.callback_query.from_user.id = 333
+    mock_update.callback_query.from_user.first_name = "User333"
+    mock_update.callback_query.message.chat.id = chat_id
+    mock_update.callback_query.message.message_id = 888
+    await leave_lobby_callback(mock_update, mock_context)
+
+    mock_context.bot.edit_message_text.reset_mock()
+
+    # 333 rejoins
+    await join_lobby_callback(mock_update, mock_context)
+
+    # Vote is back in the active tally
+    calls = mock_context.bot.edit_message_text.call_args_list
+    assert calls, "render_poll_message should have been called on rejoin"
+    last_render_text = calls[-1].kwargs.get("text") or calls[-1].args[0]
+
+    assert "1 vote" in last_render_text, (
+        f"333's vote should resume counting after rejoin. Got: {last_render_text!r}"
+    )
+    assert "**1** - GameA" in last_render_text, (
+        f"GameA should show 1 active vote after rejoin. Got: {last_render_text!r}"
+    )


### PR DESCRIPTION
## Summary
- Closes #49 — when a player leaves a session with an active poll, their already-cast votes no longer count toward the tally, voter list, or close-poll winner.
- Mirrors the existing game-suspension model: votes stay in the DB so a rejoin auto-resumes them, but they're filtered out everywhere they'd be displayed or scored.
- New `get_active_member_ids(session, chat_id)` helper; `render_poll_message` and `PollService.close_poll` filter votes by current `SessionPlayer` membership.

## Test plan
- [x] `tests/test_vote_pruning.py` — three new cases: leaver vote excluded from render, leaver vote excluded from `close_poll` winner, leave-then-rejoin restores the vote.
- [x] `tests/test_poll_edge_cases.py::test_render_anonymous_poll` — fixture had no `SessionPlayer` for the voter (it relied on the now-fixed bug); added the missing membership row.
- [x] Full suite: 175 passed, ruff + mypy clean.