### PR TITLE
ci: adopt uv dependabot ecosystem, add docker, SHA-pin all actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,39 @@
 version: 2
 updates:
-  # Note: Dependabot uses "pip" ecosystem for Python, which works with uv projects
-  # since pyproject.toml dependency format is compatible
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      python-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      python-security:
+        applies-to: security-updates
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
       prefix: "chore(deps)"
+      include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -56,7 +56,7 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,14 +44,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
       - name: Google Auth
         id: auth
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
           service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
@@ -106,7 +106,7 @@ jobs:
           sync_secret gnd-bgg-api-token "$BGG_API_TOKEN"
 
       - name: Deploy to Cloud Run
-        uses: google-github-actions/deploy-cloudrun@v3
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
         with:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.REGION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,19 +23,19 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
           client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
- Switch python dependabot ecosystem from `pip` to native `uv` (GA April 2025); add minor/patch + security groups to consolidate transitive bumps.
- Add `docker` ecosystem so the `Dockerfile` base image and `ghcr.io/astral-sh/uv` are auto-bumped (previously frozen).
- Group `github-actions` minor/patch updates; switch their commit prefix to `ci`.
- SHA-pin previously tag-pinned first-party actions: `actions/checkout@v6`, `actions/setup-python@v6`, `actions/create-github-app-token@v3`, `google-github-actions/auth@v3`, `google-github-actions/deploy-cloudrun@v3`.

## Why
Dependabot was already silently operating in uv mode against `uv.lock` via auto-detection while the config still declared `pip` — fragile and misleading. The docker ecosystem gap meant base-image CVEs would never be surfaced. Tag-pinned actions are an inconsistent hardening posture given third-party actions in this repo are already SHA-pinned.

## Test plan
- [ ] CI workflow runs green on this PR (uses the SHA-pinned `actions/checkout@v6`).
- [ ] After merge, dependabot opens its next batch under the new `uv` ecosystem (branch prefix `dependabot/uv/...`).
- [ ] After merge, a `docker` PR appears proposing a digest bump for `python:3.12-slim` and/or `ghcr.io/astral-sh/uv:0.6`.
- [ ] Next minor/patch python bump arrives as a grouped PR titled `chore(deps): bump the python-minor-patch group`.