### PR TITLE
fix(bgg): refresh community_unplayable_counts on force sync

### DIFF
--- a/scripts/refresh_community_player_counts.py
+++ b/scripts/refresh_community_player_counts.py
@@ -1,8 +1,13 @@
-"""Refresh community_unplayable_counts for all games with the field unpopulated.
+"""Refresh community_unplayable_counts for every BGG-sourced game.
 
 Hits BGG /thing once per game and writes the parsed CSV (or empty string if the
 poll exists but no count met the blocklist threshold) back to the row. Safe to
-re-run; only games where the field is NULL are touched.
+re-run; idempotent for any game where the parser's verdict hasn't changed.
+
+Reprocesses every BGG-sourced row (positive ID) regardless of current value so
+that algorithm changes to _extract_unplayable_counts propagate to rows that
+were populated under the old logic. Manually-added games (negative IDs) are
+skipped — they have no BGG /thing entry.
 """
 
 import asyncio
@@ -36,12 +41,10 @@ async def refresh_community_player_counts() -> None:
     bgg = BGGClient()
 
     async with db.AsyncSessionLocal() as session:
-        result = await session.execute(
-            select(Game).where(Game.community_unplayable_counts.is_(None), Game.id > 0)
-        )
+        result = await session.execute(select(Game).where(Game.id > 0))
         games = result.scalars().all()
 
-        print(f"Found {len(games)} games with no community_unplayable_counts")
+        print(f"Found {len(games)} BGG-sourced games to reprocess")
 
         updated = 0
         blocked_total = 0

--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -389,51 +389,65 @@ async def set_bgg(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
             await session.commit()
 
-            # Find ALL games in collection that still need complexity
-            games_needing_complexity = []
+            # Pick which games need a /thing fetch. Force sync hits every game so
+            # algorithm-driven fields (complexity, community_unplayable_counts) get
+            # refreshed even when complexity is already present — that's what makes
+            # `/setbgg <user> force` the user-facing recovery path after we ship a
+            # parser change.
+            games_needing_details = []
             for g in games:
                 db_game = await session.get(Game, g.id)
-                if db_game and (not db_game.complexity or db_game.complexity <= 0):
-                    games_needing_complexity.append(g.id)
+                if not db_game:
+                    continue
+                if force_update or not db_game.complexity or db_game.complexity <= 0:
+                    games_needing_details.append(g.id)
 
-            # Fetch detailed complexity for games that need it
             complexity_updated = 0
-            if games_needing_complexity:
+            if games_needing_details:
                 # Update status message instead of sending new one
                 with contextlib.suppress(Exception):
                     await status_msg.edit_text(
                         f"⏳ Syncing BGG collection for {bgg_username}\n"
-                        f"• Fetching complexity: 0/{len(games_needing_complexity)}..."
+                        f"• Fetching game details: 0/{len(games_needing_details)}..."
                     )
 
                 import asyncio
 
-                total_complexity = len(games_needing_complexity)
+                total_details = len(games_needing_details)
                 progress_every = 20
-                for i, game_id in enumerate(games_needing_complexity):
+                for i, game_id in enumerate(games_needing_details):
                     try:
                         details = await bgg.get_game_details(game_id)
-                        if details and details.complexity and details.complexity > 0:
+                        if details:
                             game_obj = await session.get(Game, game_id)
                             if game_obj:
-                                game_obj.complexity = details.complexity
-                                complexity_updated += 1
+                                if details.complexity and details.complexity > 0:
+                                    game_obj.complexity = details.complexity
+                                    complexity_updated += 1
+                                # Persist parsed value so algorithm changes propagate.
+                                # None means "no poll on /thing"; store "" so we don't
+                                # keep retrying. Matches refresh_community_player_counts.
+                                game_obj.community_unplayable_counts = (
+                                    details.community_unplayable_counts
+                                    if details.community_unplayable_counts is not None
+                                    else ""
+                                )
 
                         # Commit every 10 games to avoid long transactions
                         if (i + 1) % 10 == 0:
                             await session.commit()
 
                         # Throttled progress update so the user knows it's alive
-                        if (i + 1) % progress_every == 0 and (i + 1) < total_complexity:
+                        if (i + 1) % progress_every == 0 and (i + 1) < total_details:
                             with contextlib.suppress(Exception):
                                 await status_msg.edit_text(
                                     f"⏳ Syncing BGG collection for {bgg_username}\n"
-                                    f"• Fetching complexity: {i + 1}/{total_complexity}..."
+                                    f"• Fetching game details: {i + 1}/{total_details}..."
                                 )
 
                         await asyncio.sleep(0.5)  # Rate limit
                     except Exception as e:
-                        logger.warning(f"Failed to fetch complexity for game {game_id}: {e}")
+                        logger.warning(f"Failed to fetch details for game {game_id}: {e}")
                         continue
                 await session.commit()
 

--- a/tests/test_handlers_game.py
+++ b/tests/test_handlers_game.py
@@ -604,3 +604,123 @@ async def test_addgame_bgg_search_auto_stars(mock_update, mock_context):
         stmt = select(Collection).where(Collection.game_id == 100)
         col = (await session.execute(stmt)).scalar_one()
         assert col.state == GameState.STARRED
+
+
+@pytest.mark.asyncio
+async def test_setbgg_force_refreshes_community_unplayable_counts(mock_update, mock_context):
+    """/setbgg ... force re-fetches /thing for every game and overwrites stale
+    community_unplayable_counts — the user-facing recovery path after a parser
+    change. Existing complexity must not gate the refresh."""
+    mock_context.args = ["testuser", "force"]
+
+    async with db.AsyncSessionLocal() as session:
+        user = User(telegram_id=111, telegram_name="TestUser", bgg_username="testuser")
+        session.add(user)
+        # LotR: Journeys with a stale "5" left over from the old algorithm.
+        # Complexity is already populated, so the old gate would have skipped it.
+        session.add(
+            Game(
+                id=269385,
+                name="The Lord of the Rings: Journeys in Middle-Earth",
+                min_players=1,
+                max_players=5,
+                playing_time=60,
+                complexity=2.5,
+                community_unplayable_counts="5",
+            )
+        )
+        session.add(Collection(user_id=111, game_id=269385, state=GameState.INCLUDED))
+        await session.commit()
+
+    refreshed_game = Game(
+        id=269385,
+        name="The Lord of the Rings: Journeys in Middle-Earth",
+        min_players=1,
+        max_players=5,
+        playing_time=60,
+        complexity=2.5,
+        community_unplayable_counts="",
+    )
+
+    with patch("src.bot.handlers.BGGClient") as MockBGG:
+        mock_client = MockBGG.return_value
+        mock_client.fetch_collection = AsyncMock(
+            return_value=[
+                Game(
+                    id=269385,
+                    name="The Lord of the Rings: Journeys in Middle-Earth",
+                    min_players=1,
+                    max_players=5,
+                    playing_time=60,
+                    complexity=2.5,
+                )
+            ]
+        )
+        mock_client.fetch_expansions = AsyncMock(return_value=[])
+        mock_client.get_game_details = AsyncMock(return_value=refreshed_game)
+
+        await set_bgg(mock_update, mock_context)
+
+        mock_client.get_game_details.assert_awaited_with(269385)
+
+    async with db.AsyncSessionLocal() as session:
+        stored = await session.get(Game, 269385)
+        assert stored.community_unplayable_counts == ""
+
+
+@pytest.mark.asyncio
+async def test_setbgg_force_persists_no_poll_as_empty_string(mock_update, mock_context):
+    """When /thing has no suggested_numplayers poll, get_game_details returns
+    community_unplayable_counts=None. Force sync must persist that as "" so we
+    don't keep retrying on every subsequent sync."""
+    mock_context.args = ["testuser", "force"]
+
+    async with db.AsyncSessionLocal() as session:
+        user = User(telegram_id=111, telegram_name="TestUser", bgg_username="testuser")
+        session.add(user)
+        session.add(
+            Game(
+                id=42,
+                name="ObscureGame",
+                min_players=2,
+                max_players=4,
+                playing_time=60,
+                complexity=2.0,
+                community_unplayable_counts=None,
+            )
+        )
+        session.add(Collection(user_id=111, game_id=42, state=GameState.INCLUDED))
+        await session.commit()
+
+    refreshed_game = Game(
+        id=42,
+        name="ObscureGame",
+        min_players=2,
+        max_players=4,
+        playing_time=60,
+        complexity=2.0,
+        community_unplayable_counts=None,
+    )
+
+    with patch("src.bot.handlers.BGGClient") as MockBGG:
+        mock_client = MockBGG.return_value
+        mock_client.fetch_collection = AsyncMock(
+            return_value=[
+                Game(
+                    id=42,
+                    name="ObscureGame",
+                    min_players=2,
+                    max_players=4,
+                    playing_time=60,
+                    complexity=2.0,
+                )
+            ]
+        )
+        mock_client.fetch_expansions = AsyncMock(return_value=[])
+        mock_client.get_game_details = AsyncMock(return_value=refreshed_game)
+
+        await set_bgg(mock_update, mock_context)
+
+    async with db.AsyncSessionLocal() as session:
+        stored = await session.get(Game, 42)
+        assert stored.community_unplayable_counts == ""


### PR DESCRIPTION
## Summary

- `/setbgg <user> force` now re-fetches `/thing` for every game in the collection and rewrites `Game.community_unplayable_counts` from the freshly parsed value, so parser changes to `_extract_unplayable_counts` propagate to rows populated under earlier logic.
- `scripts/refresh_community_player_counts.py` drops the `IS NULL` filter and reprocesses every BGG-sourced row, giving operators a bulk recovery path.
- Adds tests covering the stale-`"5"` overwrite (LotR: Journeys in Middle-Earth) and the `None`-from-`/thing` → `""` persistence case.

## Why

Reported: *The Lord of the Rings: Journeys in Middle-Earth* missing from a 5-player poll despite the publisher listing it as 1-5.

Root cause: the original #51 algorithm flagged np=5 as unplayable (NotRec=211/304, 69.4%) and wrote `"5"` to the column. #57 fixed the algorithm so the publisher's max is never blocked, but the refresh script's selector was `IS NULL`, and no code path re-fetched `/thing` for already-populated rows — so the data never caught up to the parser. Same trap could be hiding for any game whose pre-#57 verdict differs from the post-#57 verdict (e.g. Deep Regrets).

## Deployment

After this deploys, **either**:
- Run `uv run python scripts/refresh_community_player_counts.py` once against prod (recommended, one pass over all rows), **or**
- Ask affected users to run `/setbgg <username> force` to recover their own collections.

Both paths now overwrite stale values.

## Test plan

- [x] `uv run pytest tests/test_handlers_game.py tests/test_bgg.py tests/test_logic.py tests/test_expansion_sync.py` — 61 passed
- [x] `uv run ruff check` on touched files — clean
- [ ] After deploy: run the refresh script and confirm LotR: Journeys row updates from `"5"` → `""`
- [ ] After deploy: open a 5-player poll with a collection that contains LotR: Journeys and confirm it appears