### PR TITLE
ci(dependabot): add patterns filter to python-security group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
           - "patch"
       python-security:
         applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Add `patterns: ['*']` to the `python-security` group in `.github/dependabot.yml`.

## Why
The dependabot config check on #62's merge run failed with:

> The property '#/updates/0/groups/python-security' of type object did not match one or more of the required schemas

The group declared only `applies-to: security-updates`, which is a modifier — not a selector. Dependabot's schema requires every group to specify at least one of `patterns`, `dependency-type`, or `update-types`. `patterns: ['*']` matches the original intent (consolidate every security-update PR into one grouped batch).

## Test plan
- [ ] Dependabot config validation passes on this PR.
- [ ] First future security advisory bump arrives as a single grouped PR titled `chore(deps): bump the python-security group`.