### PR TITLE
perf(poll): parallelize votes and coalesce custom-poll re-renders

### DIFF
--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -2989,8 +2989,10 @@ async def custom_poll_vote_callback(update: Update, context: ContextTypes.DEFAUL
         # Use PollService for vote casting
         vote_limit = session_obj.vote_limit if session_obj else VoteLimit.UNLIMITED
 
-        # Calculate valid games count for auto-limit (include user-added games)
-        valid_games, _ = await get_session_valid_games(session, chat_id)
+        # Fetch valid games once and reuse for both the vote-limit check and the
+        # UI render below — the game set can't change while casting a vote, so a
+        # second fetch would be wasted work (and a wasted Cloud SQL round-trip).
+        valid_games, priority_ids = await get_session_valid_games(session, chat_id)
         valid_games = await _merge_added_games(session, poll_id, valid_games)
         game_count = len(valid_games) if valid_games else 0
         valid_game_ids = {g.id for g in valid_games}
@@ -3013,15 +3015,16 @@ async def custom_poll_vote_callback(update: Update, context: ContextTypes.DEFAUL
             valid_category_levels=valid_category_levels,
         )
 
-        await session.commit()
+        # cast_vote commits internally; no extra commit needed here.
         with contextlib.suppress(telegram.error.BadRequest):
             await query.answer(result.message)
 
-        if result.success:
-            # Refresh UI
-            priority_ids = set()  # Optimized: re-fetch inside get_session_valid_games
-            valid_games, priority_ids = await get_session_valid_games(session, chat_id)
-
+        # Debounce the re-render so a burst of votes collapses into one edit.
+        # Fall back to an inline render (reusing the games already fetched
+        # above) if the job queue isn't available.
+        if result.success and not _schedule_poll_render(
+            context, chat_id, game_poll.message_id, poll_id
+        ):
             await render_poll_message(
                 context.bot,
                 chat_id,
@@ -3030,6 +3033,7 @@ async def custom_poll_vote_callback(update: Update, context: ContextTypes.DEFAUL
                 poll_id,
                 valid_games,
                 priority_ids,
+                already_merged=True,
             )
 
 
@@ -3092,10 +3096,17 @@ async def _merge_added_games(session, poll_id: str, games: list) -> list:
     return merged
 
 
-async def render_poll_message(bot, chat_id, message_id, session, poll_id, games, priority_ids):
-    """Update custom poll message with current vote state."""
+async def render_poll_message(
+    bot, chat_id, message_id, session, poll_id, games, priority_ids, already_merged=False
+):
+    """Update custom poll message with current vote state.
+
+    Set already_merged=True when the caller has already folded user-added games
+    into `games` (via _merge_added_games), to skip a redundant query.
+    """
     # Include user-added games (from allow_adding_options)
-    games = await _merge_added_games(session, poll_id, games)
+    if not already_merged:
+        games = await _merge_added_games(session, poll_id, games)
 
     # Fetch all votes for this poll, then drop votes from users who have left
     # the lobby. Rows stay in the DB (so a rejoin auto-resumes them) but are
@@ -3304,6 +3315,65 @@ async def render_poll_message(bot, chat_id, message_id, session, poll_id, games,
             logger.warning(f"Failed to update poll message: {e}")
 
 
+# Debounce window for coalescing vote-driven re-renders. A burst of votes within
+# this window collapses into a single edit_message_text call, which avoids
+# Telegram's per-message edit rate limit (the cause of the laggy top-of-poll
+# tally) and cuts redundant DB renders.
+_POLL_RENDER_DEBOUNCE_SECONDS = 0.5
+
+
+async def _render_poll_job(context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Job-queue callback that renders a poll from fresh state.
+
+    Runs after the debounce window so it reflects every vote cast during the
+    burst, not just the one that scheduled it.
+    """
+    data = cast(dict, context.job.data)
+    poll_id = data["poll_id"]
+    chat_id = data["chat_id"]
+    message_id = data["message_id"]
+    async with db.AsyncSessionLocal() as session:
+        # The poll may have been closed during the debounce window — closing
+        # deletes the record and rewrites the message to show results. Skip the
+        # render so we don't clobber the results message with a stale tally.
+        if await session.get(GameNightPoll, poll_id) is None:
+            return
+        valid_games, priority_ids = await get_session_valid_games(session, chat_id)
+        await render_poll_message(
+            context.bot, chat_id, message_id, session, poll_id, valid_games, priority_ids
+        )
+
+
+def _schedule_poll_render(
+    context: ContextTypes.DEFAULT_TYPE, chat_id: int, message_id: int, poll_id: str
+) -> bool:
+    """Debounce a poll re-render: cancel any pending render for this poll and
+    schedule a fresh one. Returns False if no job queue is available (caller
+    should then render inline as a fallback)."""
+    job_queue = context.job_queue
+    if job_queue is None:
+        return False
+    name = f"render:{poll_id}"
+    for job in job_queue.get_jobs_by_name(name):
+        job.schedule_removal()
+    job_queue.run_once(
+        _render_poll_job,
+        when=_POLL_RENDER_DEBOUNCE_SECONDS,
+        name=name,
+        data={"chat_id": chat_id, "message_id": message_id, "poll_id": poll_id},
+    )
+    return True
+
+
+def _cancel_poll_render(context: ContextTypes.DEFAULT_TYPE, poll_id: str) -> None:
+    """Cancel any pending debounced render for a poll (e.g. on close)."""
+    job_queue = context.job_queue
+    if job_queue is None:
+        return
+    for job in job_queue.get_jobs_by_name(f"render:{poll_id}"):
+        job.schedule_removal()
+
+
 # ---------------------------------------------------------------------------- #
 # Poll Action Handlers (extracted from custom_poll_action_callback)
 # ---------------------------------------------------------------------------- #
@@ -3392,11 +3462,14 @@ async def _handle_poll_category_vote(
             valid_category_levels=valid_category_levels,
         )
 
-        await session.commit()
+        # cast_vote commits internally; no extra commit needed here.
         await query.answer(result.message)
 
-        if result.success:
-            # Refresh UI
+        # Debounce the re-render (see custom_poll_vote_callback). Inline
+        # fallback reuses the already-merged games from above.
+        if result.success and not _schedule_poll_render(
+            context, chat_id, query.message.message_id, poll_id
+        ):
             await render_poll_message(
                 context.bot,
                 chat_id,
@@ -3405,6 +3478,7 @@ async def _handle_poll_category_vote(
                 poll_id,
                 valid_games,
                 priority_ids,
+                already_merged=True,
             )
 
 
@@ -3412,6 +3486,10 @@ async def _handle_poll_close(query, context: ContextTypes.DEFAULT_TYPE, poll_id:
     """Close the poll, resolve category votes, calculate winner, and end session."""
     await query.answer("Closing poll...")
     chat_id = query.message.chat.id
+
+    # Drop any pending debounced render so it can't fire after close and
+    # overwrite the results message with a stale tally.
+    _cancel_poll_render(context, poll_id)
 
     async with db.AsyncSessionLocal() as session:
         game_poll = await session.get(GameNightPoll, poll_id)

--- a/src/bot/main.py
+++ b/src/bot/main.py
@@ -59,7 +59,10 @@ def main():
         logger.error("TELEGRAM_BOT_TOKEN not set!")
         sys.exit(1)
 
-    app = ApplicationBuilder().token(token).build()
+    # concurrent_updates lets votes from different users process in parallel
+    # instead of serializing one-update-at-a-time. Safe here because cast_vote
+    # uses a row-level lock (Postgres) + IntegrityError handling for races.
+    app = ApplicationBuilder().token(token).concurrent_updates(True).build()
 
     # Handlers
     app.add_handler(CommandHandler("start", start))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,5 +103,10 @@ def mock_context():
     context.bot.pin_chat_message = AsyncMock()
     context.bot.unpin_chat_message = AsyncMock()
 
+    # Default to no job queue so vote handlers take the inline-render fallback
+    # path (which calls edit_message_text directly, as these tests assert).
+    # Debounce-specific tests inject their own fake job queue.
+    context.job_queue = None
+
     context.args = []
     return context

--- a/tests/test_custom_poll.py
+++ b/tests/test_custom_poll.py
@@ -11,6 +11,7 @@ import pytest
 from sqlalchemy import select
 
 from src.bot.handlers import (
+    _render_poll_job,
     _wrap_button_label,
     create_poll,
     custom_poll_action_callback,
@@ -2419,3 +2420,155 @@ async def test_render_poll_long_name_with_vote_keeps_count_visible(mock_update, 
 
     # The count suffix lives on the last visual line of the wrapped label.
     assert long_button.split("\n")[-1].endswith(" (1)")
+
+
+# ============================================================================
+# Debounced Render (Vote Coalescing) Tests
+# ============================================================================
+
+
+class _FakeJob:
+    def __init__(self, name, data):
+        self.name = name
+        self.data = data
+        self.removed = False
+
+    def schedule_removal(self):
+        self.removed = True
+
+
+class _FakeJobQueue:
+    """Minimal stand-in for telegram.ext.JobQueue used to assert that vote
+    handlers debounce renders instead of editing the message inline."""
+
+    def __init__(self):
+        self.jobs: list[_FakeJob] = []
+
+    def get_jobs_by_name(self, name):
+        return tuple(j for j in self.jobs if j.name == name and not j.removed)
+
+    def run_once(self, callback, when, name, data):  # noqa: ARG002 - signature parity
+        self.jobs.append(_FakeJob(name, data))
+
+    def pending(self, name):
+        return [j for j in self.jobs if j.name == name and not j.removed]
+
+
+async def _seed_basic_poll(chat_id, poll_id, game_id, user_id, message_id=999):
+    async with db.AsyncSessionLocal() as session:
+        session.add(Session(chat_id=chat_id, is_active=True, poll_type=PollType.CUSTOM))
+        session.add_all(
+            [
+                User(telegram_id=user_id, telegram_name="Voter"),
+                User(telegram_id=user_id + 1, telegram_name="Other"),
+            ]
+        )
+        await session.flush()
+        session.add(
+            Game(
+                id=game_id,
+                name="TestGame",
+                min_players=2,
+                max_players=4,
+                playing_time=60,
+                complexity=2.0,
+            )
+        )
+        await session.flush()
+        session.add_all(
+            [
+                Collection(user_id=user_id, game_id=game_id),
+                Collection(user_id=user_id + 1, game_id=game_id),
+                SessionPlayer(session_id=chat_id, user_id=user_id),
+                SessionPlayer(session_id=chat_id, user_id=user_id + 1),
+                GameNightPoll(poll_id=poll_id, chat_id=chat_id, message_id=message_id),
+            ]
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_vote_schedules_debounced_render_instead_of_inline_edit(mock_update, mock_context):
+    """With a job queue present, a vote schedules a render job and does NOT
+    edit the message inline (the edit happens later, in the coalesced job)."""
+    chat_id, poll_id, game_id, user_id = 12345, "poll_12345_1", 1, 111
+    await _seed_basic_poll(chat_id, poll_id, game_id, user_id)
+
+    mock_context.job_queue = _FakeJobQueue()
+    mock_update.callback_query.data = f"vote:{poll_id}:{game_id}"
+    mock_update.callback_query.from_user.id = user_id
+    mock_update.callback_query.from_user.first_name = "Voter"
+
+    await custom_poll_vote_callback(mock_update, mock_context)
+
+    # Vote persisted + acknowledged immediately (non-blocking UX preserved).
+    mock_update.callback_query.answer.assert_called_with("Vote recorded")
+    # Render is deferred to the job queue, not edited inline.
+    mock_context.bot.edit_message_text.assert_not_called()
+    pending = mock_context.job_queue.pending(f"render:{poll_id}")
+    assert len(pending) == 1
+    assert pending[0].data == {
+        "chat_id": chat_id,
+        "message_id": 999,
+        "poll_id": poll_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_rapid_votes_coalesce_to_single_pending_render(mock_update, mock_context):
+    """A burst of votes leaves exactly one pending render job: each new vote
+    cancels the previous job before scheduling its own."""
+    chat_id, poll_id, user_id = 12345, "poll_12345_2", 111
+    await _seed_basic_poll(chat_id, poll_id, 1, user_id)
+    async with db.AsyncSessionLocal() as session:
+        session.add(
+            Game(id=2, name="Second", min_players=2, max_players=4, playing_time=60, complexity=2.0)
+        )
+        await session.flush()
+        session.add_all(
+            [
+                Collection(user_id=user_id, game_id=2),
+                Collection(user_id=user_id + 1, game_id=2),
+            ]
+        )
+        await session.commit()
+
+    mock_context.job_queue = _FakeJobQueue()
+    mock_update.callback_query.from_user.id = user_id
+    mock_update.callback_query.from_user.first_name = "Voter"
+
+    for game_id in (1, 2):
+        mock_update.callback_query.data = f"vote:{poll_id}:{game_id}"
+        await custom_poll_vote_callback(mock_update, mock_context)
+
+    # Two votes scheduled two jobs but the first was cancelled → one live job.
+    assert len(mock_context.job_queue.pending(f"render:{poll_id}")) == 1
+    assert sum(j.removed for j in mock_context.job_queue.jobs) == 1
+
+
+@pytest.mark.asyncio
+async def test_render_job_edits_message(mock_context):
+    """The debounced job renders the live poll state to the message."""
+    chat_id, poll_id, game_id, user_id = 12345, "poll_12345_3", 1, 111
+    await _seed_basic_poll(chat_id, poll_id, game_id, user_id)
+
+    mock_context.job = MagicMock()
+    mock_context.job.data = {"chat_id": chat_id, "message_id": 999, "poll_id": poll_id}
+
+    await _render_poll_job(mock_context)
+
+    mock_context.bot.edit_message_text.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_render_job_skips_closed_poll(mock_context):
+    """If the poll was closed (record gone) during the debounce window, the job
+    is a no-op so it can't clobber the results message."""
+    chat_id, poll_id = 12345, "poll_does_not_exist"
+
+    mock_context.job = MagicMock()
+    mock_context.job.data = {"chat_id": chat_id, "message_id": 999, "poll_id": poll_id}
+
+    await _render_poll_job(mock_context)
+
+    mock_context.bot.edit_message_text.assert_not_called()


### PR DESCRIPTION
## Problem

Custom-poll voting feels slow during group play. Two compounding causes:

1. **Updates were processed sequentially.** `concurrent_updates` was left at its default (off), so each vote handler ran to completion — including its ~13 DB round-trips and a Telegram `edit_message_text` — before the next update started. In a group, every vote queued behind everyone ahead of it.
2. **Every vote triggered its own message edit.** Telegram rate-limits edits to a single message, so bursts got throttled, making the top-of-poll tally lag badly.
3. **Redundant per-vote DB work.** The heavy `Collection ⋈ Game` join (`get_session_valid_games`) ran twice per vote, plus a duplicate commit and a second added-games merge.

## Changes

- **Enable `concurrent_updates(True)`** so votes from different users process in parallel. Safe — `cast_vote` already guards races via a Postgres row lock + `IntegrityError` handling, and the pool supports the concurrency.
- **Debounce re-renders via the job queue.** A burst of votes now collapses into a single `edit_message_text` (`render:<poll_id>` job, 0.5s window). The render job skips closed polls and is cancelled on close, so it can't clobber the results message. Falls back to inline render when no job queue is present.
- **Cut redundant per-vote DB work:** reuse the single valid-games fetch, drop the duplicate `session.commit()`, and add `render_poll_message(already_merged=True)` to skip a second merge.

The vote is still committed and `query.answer()`'d immediately — the UI never blocks waiting on the DB.

## Impact

Roughly halves DB round-trips per vote and cuts Telegram API calls (cost-positive on Cloud Run + Cloud SQL), while votes process in parallel and the tally updates once per burst instead of fighting the rate limiter.

## Tests

- Existing `mock_context` defaults `job_queue = None` so the suite exercises the inline fallback it already asserts.
- 4 new tests: deferral-instead-of-inline-edit, burst coalescing to one live job, the job rendering, and the job no-op'ing on a closed poll.
- Full suite: 188 passed. ruff + format + mypy clean.