### PR TITLE
ci(deploy): surface deployed version in job summary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,6 +128,21 @@ jobs:
             --cpu-boost
             --allow-unauthenticated
 
+      - name: Job summary
+        if: always()
+        run: |
+          ref="${{ inputs.ref || github.sha }}"
+          {
+            echo "## Cloud Run deploy"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Deployed ref | \`$ref\` |"
+            echo "| Image | \`$SERVICE_NAME:$ref\` |"
+            echo "| Region | \`$REGION\` |"
+            echo "| Triggered by | \`${{ github.event_name }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Smoke test
         run: |
           status=$(curl -s -o /dev/null -w '%{http_code}' "${{ vars.WEBHOOK_URL }}/telegram")


### PR DESCRIPTION
## Why

When PR #82 merged, the `release → deploy` chain worked correctly and Cloud Run was updated to `v1.1.12` automatically. But the deploy was easy to mistake for "didn't run": it executes as a **reusable workflow** (`workflow_call`) nested under the **Release** run, so it never shows up as its own entry in the **Deploy to Cloud Run** workflow tab — that tab only lists `workflow_dispatch` runs.

## What

Adds a `Job summary` step (runs with `if: always()`) that writes the deployed **ref**, **image**, **region**, and **trigger** to `$GITHUB_STEP_SUMMARY`, so the deploy outcome is unambiguous from the Release run page.

No behavioral change to the deploy itself.