### PR TITLE
fix(poll): throttle custom-poll renders so sustained voting can't freeze the tally

### DIFF
--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -3347,15 +3347,25 @@ async def _render_poll_job(context: ContextTypes.DEFAULT_TYPE) -> None:
 def _schedule_poll_render(
     context: ContextTypes.DEFAULT_TYPE, chat_id: int, message_id: int, poll_id: str
 ) -> bool:
-    """Debounce a poll re-render: cancel any pending render for this poll and
-    schedule a fresh one. Returns False if no job queue is available (caller
-    should then render inline as a fallback)."""
+    """Throttle a poll re-render: ensure exactly one render is pending for this
+    poll, firing _POLL_RENDER_DEBOUNCE_SECONDS after the *first* vote of a burst.
+    Returns False if no job queue is available (caller should then render inline
+    as a fallback).
+
+    This is a leading-window throttle, NOT a trailing-edge debounce: if a render
+    is already pending we leave it in place rather than cancelling and pushing it
+    out. A pure debounce starves under sustained voting — every vote within the
+    window reschedules the job, so it never fires and the tally freezes. The job
+    reads fresh state when it runs, so one render per window reflects every vote
+    cast in that window; a vote arriving after the job fires schedules the next
+    one, guaranteeing a trailing render once the burst ends."""
     job_queue = context.job_queue
     if job_queue is None:
         return False
     name = f"render:{poll_id}"
-    for job in job_queue.get_jobs_by_name(name):
-        job.schedule_removal()
+    if job_queue.get_jobs_by_name(name):
+        # A render is already pending for this poll; it will pick up this vote.
+        return True
     job_queue.run_once(
         _render_poll_job,
         when=_POLL_RENDER_DEBOUNCE_SECONDS,

--- a/tests/test_custom_poll.py
+++ b/tests/test_custom_poll.py
@@ -2516,8 +2516,10 @@ async def test_vote_schedules_debounced_render_instead_of_inline_edit(mock_updat
 
 @pytest.mark.asyncio
 async def test_rapid_votes_coalesce_to_single_pending_render(mock_update, mock_context):
-    """A burst of votes leaves exactly one pending render job: each new vote
-    cancels the previous job before scheduling its own."""
+    """A burst of votes leaves exactly one pending render job: the first vote
+    schedules it and later votes in the window leave it in place (throttle, not
+    debounce — so sustained voting can't starve the render and freeze the tally).
+    The pending job reads fresh state when it fires, so it reflects every vote."""
     chat_id, poll_id, user_id = 12345, "poll_12345_2", 111
     await _seed_basic_poll(chat_id, poll_id, 1, user_id)
     async with db.AsyncSessionLocal() as session:
@@ -2541,9 +2543,10 @@ async def test_rapid_votes_coalesce_to_single_pending_render(mock_update, mock_c
         mock_update.callback_query.data = f"vote:{poll_id}:{game_id}"
         await custom_poll_vote_callback(mock_update, mock_context)
 
-    # Two votes scheduled two jobs but the first was cancelled → one live job.
+    # The first vote scheduled the only job; the second reused it instead of
+    # cancelling and rescheduling → one live job, nothing removed (no starvation).
     assert len(mock_context.job_queue.pending(f"render:{poll_id}")) == 1
-    assert sum(j.removed for j in mock_context.job_queue.jobs) == 1
+    assert sum(j.removed for j in mock_context.job_queue.jobs) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A live custom poll showed only a handful of votes in the message while the DB held many more. Introduced by #82.

#82 made vote-driven re-renders a **trailing-edge debounce**: every vote cancelled the pending render job and rescheduled it 0.5s later (`_schedule_poll_render`). Under sustained voting (votes landing < 0.5s apart) the job was cancelled-and-rescheduled indefinitely and **never fired**, so the message froze at the tally rendered before the burst began. Votes were still committed immediately, hence the UI/DB divergence.

This only manifests in production because the `python-telegram-bot[job-queue]` extra is installed, so the bot takes the debounce path rather than the inline-render fallback.

## Fix

Replace the debounce with a **leading-window throttle**: if a render is already pending for the poll, leave it in place instead of cancelling and pushing it out.

- A render fires ~0.5s after the first vote of a burst, and roughly every 0.5s during sustained voting.
- A vote arriving after the job fires schedules the next one, guaranteeing a trailing render once the burst ends.
- The job reads fresh state when it runs, so one render per window still reflects every vote in that window — coalescing from #82 is preserved.

## Tests

- Updated `test_rapid_votes_coalesce_to_single_pending_render` to assert throttle semantics (one pending job, nothing cancelled).
- Full suite: 188 passed. `ruff check`/`ruff format`/`mypy` clean.

## Note

The currently-frozen poll message self-heals on the next vote after a >0.5s gap (or a 🔄 Refresh tap) once this is deployed.