### PR TITLE
fix(poll): paginate custom-poll keyboard by complexity for large game lists

### DIFF
--- a/alembic/versions/2026_06_25_add_current_page_to_game_night_polls.py
+++ b/alembic/versions/2026_06_25_add_current_page_to_game_night_polls.py
@@ -1,0 +1,30 @@
+"""add current_page to game_night_polls
+
+Revision ID: a1c7e0f4d92b
+Revises: 9f2d8c4a1e3b
+Create Date: 2026-06-25 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a1c7e0f4d92b"
+down_revision: str | Sequence[str] | None = "9f2d8c4a1e3b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add current_page column tracking the displayed page of a paginated poll."""
+    with op.batch_alter_table("game_night_polls", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("current_page", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop current_page column."""
+    with op.batch_alter_table("game_night_polls", schema=None) as batch_op:
+        batch_op.drop_column("current_page")

--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -167,6 +167,15 @@ _BUTTON_MAX_LINES = 3
 # to wrap or fall back to the ellipsis placeholder.
 _BUTTON_LONG_THRESHOLD = 18
 
+# Custom-poll keyboard pagination. A single inline keyboard's serialized
+# reply_markup has a size limit; large game lists overflow it and Telegram
+# rejects the edit with "Reply markup is too long", silently freezing the poll.
+# At or below the threshold we render every complexity group in one keyboard
+# (no behaviour change). Above it we paginate one complexity category per page,
+# capping each page's game buttons so a page always stays under the limit.
+_POLL_KEYBOARD_PAGE_THRESHOLD = 60
+_POLL_KEYBOARD_PAGE_SIZE = 50
+
 
 def _wrap_button_label(prefix: str, name: str, suffix: str) -> str:
     """Build an inline-button label that wraps the name across multiple lines.
@@ -3247,50 +3256,91 @@ async def render_poll_message(
     # Build Keyboard with Complexity Grouping
     keyboard = []
 
-    # Grouped by Complexity (Descending)
-    for level in sorted(groups.keys(), reverse=True):
+    def _sorted_group(level):
+        """Order a complexity group's games for display.
+
+        Shuffle when enabled (per-group seed so adding/removing a game in one
+        group doesn't reshuffle others; id-sorted first for reproducibility),
+        otherwise sort by votes/starred. Reused whether we render every group at
+        once or paginate one group at a time.
+        """
         group = groups[level]
-
-        # Shuffle game order within group if enabled, otherwise sort by votes/starred.
-        # Use a per-group seed so adding/removing a game in one complexity group
-        # doesn't reshuffle others. Input is sorted by id first so the shuffle is
-        # reproducible regardless of DB row order.
         if shuffle:
-            sorted_group = sorted(group, key=lambda g: g.id)
-            random.Random(shuffle_seed ^ level).shuffle(sorted_group)
-        else:
-            sorted_group = sorted(group, key=sort_key)
+            sg = sorted(group, key=lambda g: g.id)
+            random.Random(shuffle_seed ^ level).shuffle(sg)
+            return sg
+        return sorted(group, key=sort_key)
 
-        # Add Separator/Header with Category Vote action
-        # Show category vote count on header (hidden when hide_results is on)
+    def _emit_group(level, group_games):
+        """Append a category-vote header row followed by this group's buttons."""
         cat_count = category_vote_counts.get(level, 0)
         show_count = cat_count > 0 and not hide_results
-        if level > 0:
-            header_text = f"--- {level} ---" if not show_count else f"--- {level} ({cat_count}) ---"
-        else:
-            header_text = "--- Unrated ---" if not show_count else f"--- Unrated ({cat_count}) ---"
+        level_name = level if level > 0 else "Unrated"
+        header_text = (
+            f"--- {level_name} ---" if not show_count else f"--- {level_name} ({cat_count}) ---"
+        )
         keyboard.append(
             [InlineKeyboardButton(header_text, callback_data=f"poll_random_vote:{poll_id}:{level}")]
         )
 
-        # When any game in the group has a long name, render the group at
-        # one button per row so wrapping has more horizontal room. Other
-        # groups stay at two-per-row to keep the keyboard compact.
-        columns = 1 if any(len(g.name) > _BUTTON_LONG_THRESHOLD for g in sorted_group) else 2
-
+        # One button per row when any name is long (more room to wrap), else two.
+        columns = 1 if any(len(g.name) > _BUTTON_LONG_THRESHOLD for g in group_games) else 2
         current_row = []
-        for g in sorted_group:
+        for g in group_games:
             count = vote_counts[g.id]
             prefix = "⭐ " if g.id in priority_ids else ""
             suffix = f" ({count})" if count > 0 and not hide_results else ""
             label = _wrap_button_label(prefix, g.name, suffix)
             current_row.append(InlineKeyboardButton(label, callback_data=f"vote:{poll_id}:{g.id}"))
-
             if len(current_row) == columns:
                 keyboard.append(current_row)
                 current_row = []
         if current_row:
             keyboard.append(current_row)
+
+    levels_desc = sorted(groups.keys(), reverse=True)
+    total_game_buttons = sum(len(groups[level]) for level in levels_desc)
+
+    if total_game_buttons <= _POLL_KEYBOARD_PAGE_THRESHOLD:
+        # Fits one keyboard: render every complexity group at once (unchanged
+        # behaviour for typical polls).
+        for level in levels_desc:
+            _emit_group(level, _sorted_group(level))
+    else:
+        # Too many buttons for a single reply_markup — Telegram rejects it with
+        # "Reply markup is too long", which silently froze large polls. Show one
+        # complexity category per page (splitting any oversized category into
+        # sub-pages) with navigation between them.
+        pages = []  # each entry: (level, games_subset)
+        for level in levels_desc:
+            sg = _sorted_group(level)
+            for i in range(0, len(sg), _POLL_KEYBOARD_PAGE_SIZE):
+                pages.append((level, sg[i : i + _POLL_KEYBOARD_PAGE_SIZE]))
+
+        current_page = (game_poll.current_page if game_poll else None) or 0
+        current_page = max(0, min(current_page, len(pages) - 1))
+        page_level, page_games = pages[current_page]
+
+        # Navigation row: arrows appear only when there's somewhere to go; the
+        # centre label is a no-op that just re-renders the current page.
+        nav_row = []
+        if current_page > 0:
+            nav_row.append(
+                InlineKeyboardButton("◀", callback_data=f"poll_page:{poll_id}:{current_page - 1}")
+            )
+        level_name = page_level if page_level > 0 else "Unrated"
+        nav_row.append(
+            InlineKeyboardButton(
+                f"📄 Complexity {level_name} · {current_page + 1}/{len(pages)}",
+                callback_data=f"poll_page:{poll_id}:{current_page}",
+            )
+        )
+        if current_page < len(pages) - 1:
+            nav_row.append(
+                InlineKeyboardButton("▶", callback_data=f"poll_page:{poll_id}:{current_page + 1}")
+            )
+        keyboard.append(nav_row)
+        _emit_group(page_level, page_games)
 
     # Add action row
     row_actions = [
@@ -3415,6 +3465,30 @@ async def _handle_poll_refresh(query, context: ContextTypes.DEFAULT_TYPE, poll_i
                 valid_games,
                 priority_ids,
             )
+
+
+async def _handle_poll_page(
+    query, context: ContextTypes.DEFAULT_TYPE, poll_id: str, page: int
+) -> None:
+    """Switch a paginated poll's shared message to the requested keyboard page.
+
+    The page is persisted on the poll so vote-driven re-renders stay on it
+    instead of snapping back to the first page. Rendered inline (not debounced)
+    so navigation feels immediate.
+    """
+    with contextlib.suppress(telegram.error.BadRequest):
+        await query.answer()
+    async with db.AsyncSessionLocal() as session:
+        game_poll = await session.get(GameNightPoll, poll_id)
+        if not game_poll:
+            return
+        game_poll.current_page = page
+        await session.commit()
+        chat_id = game_poll.chat_id
+        valid_games, priority_ids = await get_session_valid_games(session, chat_id)
+        await render_poll_message(
+            context.bot, chat_id, game_poll.message_id, session, poll_id, valid_games, priority_ids
+        )
 
 
 async def _handle_poll_category_vote(
@@ -3724,6 +3798,7 @@ async def custom_poll_action_callback(update: Update, context: ContextTypes.DEFA
     - poll_random_vote:<poll_id>:<level>
     - poll_close:<poll_id>
     - poll_add:<poll_id>
+    - poll_page:<poll_id>:<page_index>
     """
     query = update.callback_query
     data = query.data
@@ -3733,6 +3808,13 @@ async def custom_poll_action_callback(update: Update, context: ContextTypes.DEFA
 
     if action == "poll_refresh":
         await _handle_poll_refresh(query, context, poll_id)
+
+    elif action == "poll_page":
+        if len(parts) < 3:
+            with contextlib.suppress(telegram.error.BadRequest):
+                await query.answer("Invalid data")
+            return
+        await _handle_poll_page(query, context, poll_id, int(parts[2]))
 
     elif action == "poll_random_vote":
         if len(parts) < 3:

--- a/src/bot/main.py
+++ b/src/bot/main.py
@@ -88,6 +88,7 @@ def main():
     app.add_handler(CallbackQueryHandler(custom_poll_vote_callback, pattern=r"^vote:"))
     app.add_handler(CallbackQueryHandler(custom_poll_action_callback, pattern=r"^poll_refresh:"))
     app.add_handler(CallbackQueryHandler(custom_poll_action_callback, pattern=r"^poll_close:"))
+    app.add_handler(CallbackQueryHandler(custom_poll_action_callback, pattern=r"^poll_page:"))
     app.add_handler(
         CallbackQueryHandler(custom_poll_action_callback, pattern=r"^poll_random_vote:")
     )

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -171,6 +171,13 @@ class GameNightPoll(Base):
     # NULL on legacy rows / native polls (Telegram handles shuffle server-side).
     shuffle_seed: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
+    # Currently displayed keyboard page for large custom polls. When the full
+    # game keyboard would exceed Telegram's reply_markup size limit, the buttons
+    # are paginated one complexity category per page; this tracks which page the
+    # shared poll message is showing so vote-driven re-renders stay on it.
+    # NULL/0 = first page (and the only value for polls small enough to fit).
+    current_page: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     # Relationships
     votes: Mapped[list["PollVote"]] = relationship(
         back_populates="poll", cascade="all, delete-orphan"

--- a/tests/test_custom_poll.py
+++ b/tests/test_custom_poll.py
@@ -16,6 +16,7 @@ from src.bot.handlers import (
     create_poll,
     custom_poll_action_callback,
     custom_poll_vote_callback,
+    get_session_valid_games,
     join_lobby_callback,
     poll_add_select_callback,
     poll_settings_callback,
@@ -2420,6 +2421,136 @@ async def test_render_poll_long_name_with_vote_keeps_count_visible(mock_update, 
 
     # The count suffix lives on the last visual line of the wrapped label.
     assert long_button.split("\n")[-1].endswith(" (1)")
+
+
+# ============================================================================
+# Keyboard Pagination Tests (large game lists)
+# ============================================================================
+
+
+async def _seed_poll_with_complexities(chat_id, poll_id, complexities):
+    """Seed a custom poll whose single player owns one game per entry in
+    `complexities` (complexity floats). player_count is 1 so every game is valid.
+    Games get ids 1..N in order."""
+    async with db.AsyncSessionLocal() as session:
+        session.add(Session(chat_id=chat_id, is_active=True, poll_type=PollType.CUSTOM))
+        session.add(User(telegram_id=111, telegram_name="Solo"))
+        await session.flush()
+        games = [
+            Game(
+                id=i + 1,
+                name=f"Game{i + 1:03d}",
+                min_players=1,
+                max_players=8,
+                playing_time=60,
+                complexity=c,
+            )
+            for i, c in enumerate(complexities)
+        ]
+        session.add_all(games)
+        await session.flush()
+        session.add_all([Collection(user_id=111, game_id=g.id) for g in games])
+        session.add(SessionPlayer(session_id=chat_id, user_id=111))
+        session.add(GameNightPoll(poll_id=poll_id, chat_id=chat_id, message_id=999))
+        await session.commit()
+
+
+def _vote_button_ids(markup):
+    return [
+        int(btn.callback_data.split(":")[2])
+        for row in markup.inline_keyboard
+        for btn in row
+        if btn.callback_data and btn.callback_data.startswith("vote:")
+    ]
+
+
+def _page_targets(markup):
+    return [
+        btn.callback_data
+        for row in markup.inline_keyboard
+        for btn in row
+        if btn.callback_data and btn.callback_data.startswith("poll_page:")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_small_poll_renders_all_games_without_pagination(mock_context):
+    """A poll that fits one keyboard shows every game and no page navigation."""
+    chat_id, poll_id = 12345, "poll_small"
+    await _seed_poll_with_complexities(chat_id, poll_id, [2.0] * 5)
+
+    async with db.AsyncSessionLocal() as session:
+        valid_games, priority_ids = await get_session_valid_games(session, chat_id)
+        await render_poll_message(
+            mock_context.bot, chat_id, 999, session, poll_id, valid_games, priority_ids
+        )
+
+    markup = mock_context.bot.edit_message_text.call_args.kwargs["reply_markup"]
+    assert sorted(_vote_button_ids(markup)) == [1, 2, 3, 4, 5]
+    assert _page_targets(markup) == []  # no nav row
+
+
+@pytest.mark.asyncio
+async def test_large_poll_shows_one_complexity_category_per_page(mock_context):
+    """Over the size threshold, the keyboard paginates: page 1 shows only the
+    highest-complexity category and offers a 'next' button."""
+    chat_id, poll_id = 12345, "poll_big"
+    # 40 level-4 games (ids 1-40) + 40 level-2 games (ids 41-80) = 80 > threshold.
+    await _seed_poll_with_complexities(chat_id, poll_id, [4.0] * 40 + [2.0] * 40)
+
+    async with db.AsyncSessionLocal() as session:
+        valid_games, priority_ids = await get_session_valid_games(session, chat_id)
+        await render_poll_message(
+            mock_context.bot, chat_id, 999, session, poll_id, valid_games, priority_ids
+        )
+
+    markup = mock_context.bot.edit_message_text.call_args.kwargs["reply_markup"]
+    ids = _vote_button_ids(markup)
+    # Only the level-4 category (ids 1-40) is on the first page.
+    assert len(ids) == 40
+    assert all(1 <= i <= 40 for i in ids)
+    # A "next page" navigation button is present.
+    assert f"poll_page:{poll_id}:1" in _page_targets(markup)
+
+
+@pytest.mark.asyncio
+async def test_poll_page_navigation_switches_category_and_persists(mock_update, mock_context):
+    """Tapping a page button renders the next category and persists the page so
+    later vote re-renders stay on it."""
+    chat_id, poll_id = 12345, "poll_nav"
+    await _seed_poll_with_complexities(chat_id, poll_id, [4.0] * 40 + [2.0] * 40)
+
+    mock_update.callback_query.data = f"poll_page:{poll_id}:1"
+    await custom_poll_action_callback(mock_update, mock_context)
+
+    async with db.AsyncSessionLocal() as session:
+        game_poll = await session.get(GameNightPoll, poll_id)
+        assert game_poll.current_page == 1
+
+    markup = mock_context.bot.edit_message_text.call_args.kwargs["reply_markup"]
+    ids = _vote_button_ids(markup)
+    # Page 2 is the level-2 category (ids 41-80).
+    assert len(ids) == 40
+    assert all(41 <= i <= 80 for i in ids)
+
+
+@pytest.mark.asyncio
+async def test_oversized_single_category_splits_into_subpages(mock_context):
+    """A single complexity category larger than one page is capped per page so
+    the reply_markup never exceeds Telegram's limit."""
+    chat_id, poll_id = 12345, "poll_onecat"
+    await _seed_poll_with_complexities(chat_id, poll_id, [2.0] * 70)  # one category, 70 games
+
+    async with db.AsyncSessionLocal() as session:
+        valid_games, priority_ids = await get_session_valid_games(session, chat_id)
+        await render_poll_message(
+            mock_context.bot, chat_id, 999, session, poll_id, valid_games, priority_ids
+        )
+
+    markup = mock_context.bot.edit_message_text.call_args.kwargs["reply_markup"]
+    # First sub-page is capped at the page size, not all 70 games.
+    assert len(_vote_button_ids(markup)) == 50
+    assert f"poll_page:{poll_id}:1" in _page_targets(markup)
 
 
 # ============================================================================


### PR DESCRIPTION
## Problem (the real one)

Custom polls froze mid-session on the affected group: the message stuck at a few votes while the DB held many more. Confirmed from production logs — **`Reply markup is too long`**, not a Markdown error.

`render_poll_message` builds one inline button per valid game with **no cap** (the native-poll path caps options at 12; the custom poll dropped that cap to beat the 10-option limit but never added a size guard). A large combined collection produces a `reply_markup` over Telegram's size limit, so `edit_message_text` fails, the error is swallowed, and because the oversized keyboard recurs on every render the poll stops updating. Vote-count `(N)` suffixes grow the labels, which is exactly why it tipped over only after the first few votes — and why a small/new group works fine.

This predates the recent render-perf PR (#82) and is unrelated to vote suspension for users who leave (that's intended).

## Fix

- **Below a button-count threshold (60):** render every complexity group in one keyboard, exactly as before — no behaviour change for typical polls.
- **Above it:** paginate **one complexity category per page** (splitting any single oversized category into capped sub-pages of 50) with ◀ / ▶ navigation, so each edit's `reply_markup` stays well under Telegram's limit.
- Persist the displayed page on `GameNightPoll.current_page` (new nullable column + Alembic migration) so vote-driven re-renders stay on the current page instead of snapping back to page 1.
- Route `poll_page:<poll_id>:<index>` through the existing action dispatcher.

## Tests

- Small poll → all games, no nav row.
- Large poll → first page shows only the top complexity category + a next button.
- Navigating persists `current_page` and switches category.
- An oversized single category splits into capped sub-pages.
- Full suite: 192 passed. Migration upgrade/downgrade verified. `ruff`/`format`/`mypy` clean.

## Note on the current frozen poll

Once deployed, the affected poll will re-render correctly on the next vote/refresh (it'll now paginate). No DB wipe needed — clearing the DB would only have masked this until collections grew again.