### PR TITLE
fix(poll): cap custom-poll keyboard to a size budget (drop lowest complexity)

### DIFF
--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import logging
 import math
 import random
@@ -166,6 +167,123 @@ _BUTTON_MAX_LINES = 3
 # giving the wrapper twice the horizontal room and reducing how often it has
 # to wrap or fall back to the ellipsis placeholder.
 _BUTTON_LONG_THRESHOLD = 18
+
+# Telegram rejects an oversized inline keyboard with "Reply markup is too long",
+# which (since the error was swallowed) silently froze polls whose game list was
+# too big to fit one keyboard. We cap the serialized reply_markup to a safe byte
+# budget: game buttons are added highest-complexity-first and we stop before the
+# budget is exceeded, so the games that don't get an individual button are the
+# lowest-complexity ones (still votable via their complexity-category button).
+# The exact server limit isn't documented, so render_poll_message also halves
+# this budget and retries if an edit is still rejected — it self-corrects rather
+# than freezing. Category headers and the action row are always kept.
+_REPLY_MARKUP_BUDGET_BYTES = 9000
+_RENDER_MAX_ATTEMPTS = 4
+
+
+def _button_bytes(button: InlineKeyboardButton) -> int:
+    """Approximate the serialized byte cost of one inline-keyboard button.
+
+    Counts UTF-8 bytes of the compact JSON (emoji/non-ASCII counted at their
+    real byte size) plus a couple of bytes for surrounding array punctuation.
+    Used to budget the keyboard; the retry in render_poll_message covers any
+    slack between this estimate and Telegram's actual accounting.
+    """
+    payload = json.dumps(button.to_dict(), ensure_ascii=False, separators=(",", ":"))
+    return len(payload.encode("utf-8")) + 2
+
+
+def _build_poll_keyboard(
+    poll_id: str,
+    levels_desc: list[int],
+    sorted_by_level: dict[int, list],
+    vote_counts: dict[int, int],
+    priority_ids: set[int],
+    category_vote_counts: dict[int, int],
+    hide_results: bool,
+    allow_adding: bool,
+    budget_bytes: int,
+) -> tuple[list[list[InlineKeyboardButton]], int, int]:
+    """Build the custom-poll keyboard within a serialized-size budget.
+
+    Returns (keyboard, shown_games, hidden_games). A category-vote header is
+    emitted for every complexity level (so dropped games stay votable) and the
+    action row is always included; individual game buttons are added
+    highest-complexity-first until the next would exceed ``budget_bytes``, so any
+    games left without a button are the lowest-complexity ones.
+    """
+
+    def _game_button(g) -> InlineKeyboardButton:
+        count = vote_counts.get(g.id, 0)
+        prefix = "⭐ " if g.id in priority_ids else ""
+        suffix = f" ({count})" if count > 0 and not hide_results else ""
+        label = _wrap_button_label(prefix, g.name, suffix)
+        return InlineKeyboardButton(label, callback_data=f"vote:{poll_id}:{g.id}")
+
+    # Action row is fixed; reserve its cost up front.
+    action_row = [
+        InlineKeyboardButton("🔄 Refresh", callback_data=f"poll_refresh:{poll_id}"),
+        InlineKeyboardButton("🛑 Close", callback_data=f"poll_close:{poll_id}"),
+    ]
+    if allow_adding:
+        action_row.insert(1, InlineKeyboardButton("➕ Add", callback_data=f"poll_add:{poll_id}"))
+
+    used = sum(_button_bytes(b) for b in action_row)
+
+    # Reserve every level's category header (cheap, ≤6) so dropped games keep a
+    # category-vote path.
+    headers: dict[int, InlineKeyboardButton] = {}
+    for level in levels_desc:
+        cat_count = category_vote_counts.get(level, 0)
+        show_count = cat_count > 0 and not hide_results
+        level_name = level if level > 0 else "Unrated"
+        header_text = (
+            f"--- {level_name} ---" if not show_count else f"--- {level_name} ({cat_count}) ---"
+        )
+        header = InlineKeyboardButton(
+            header_text, callback_data=f"poll_random_vote:{poll_id}:{level}"
+        )
+        headers[level] = header
+        used += _button_bytes(header)
+
+    # Add game buttons highest-complexity-first until the budget is reached.
+    shown_by_level: dict[int, list] = {level: [] for level in levels_desc}
+    shown = 0
+    total = 0
+    budget_reached = False
+    for level in levels_desc:
+        for g in sorted_by_level[level]:
+            total += 1
+            if budget_reached:
+                continue
+            cost = _button_bytes(_game_button(g))
+            if used + cost > budget_bytes:
+                budget_reached = True
+                continue
+            used += cost
+            shown_by_level[level].append(g)
+            shown += 1
+
+    # Assemble the keyboard: header + this level's shown buttons, per level.
+    keyboard: list[list[InlineKeyboardButton]] = []
+    for level in levels_desc:
+        keyboard.append([headers[level]])
+        games = shown_by_level[level]
+        if not games:
+            continue
+        # One button per row when any name is long (more room to wrap), else two.
+        columns = 1 if any(len(g.name) > _BUTTON_LONG_THRESHOLD for g in games) else 2
+        current_row: list[InlineKeyboardButton] = []
+        for g in games:
+            current_row.append(_game_button(g))
+            if len(current_row) == columns:
+                keyboard.append(current_row)
+                current_row = []
+        if current_row:
+            keyboard.append(current_row)
+
+    keyboard.append(action_row)
+    return keyboard, shown, total - shown
 
 
 def _wrap_button_label(prefix: str, name: str, suffix: str) -> str:
@@ -3242,77 +3360,65 @@ async def render_poll_message(
     if not leader_found:
         text_lines.append("_No votes yet! Tap buttons below._")
 
-    text = "\n".join(text_lines)
-
-    # Build Keyboard with Complexity Grouping
-    keyboard = []
-
-    # Grouped by Complexity (Descending)
-    for level in sorted(groups.keys(), reverse=True):
+    # Pre-sort each complexity level's games once (shuffle or vote/star order).
+    # A per-group seed keeps order stable across re-renders and isolates groups
+    # from each other's changes. The keyboard builder consumes these and may
+    # include only a subset to stay within Telegram's reply_markup size limit.
+    levels_desc = sorted(groups.keys(), reverse=True)
+    sorted_by_level: dict[int, list] = {}
+    for level in levels_desc:
         group = groups[level]
-
-        # Shuffle game order within group if enabled, otherwise sort by votes/starred.
-        # Use a per-group seed so adding/removing a game in one complexity group
-        # doesn't reshuffle others. Input is sorted by id first so the shuffle is
-        # reproducible regardless of DB row order.
         if shuffle:
-            sorted_group = sorted(group, key=lambda g: g.id)
-            random.Random(shuffle_seed ^ level).shuffle(sorted_group)
+            sg = sorted(group, key=lambda g: g.id)
+            random.Random(shuffle_seed ^ level).shuffle(sg)
         else:
-            sorted_group = sorted(group, key=sort_key)
+            sg = sorted(group, key=sort_key)
+        sorted_by_level[level] = sg
 
-        # Add Separator/Header with Category Vote action
-        # Show category vote count on header (hidden when hide_results is on)
-        cat_count = category_vote_counts.get(level, 0)
-        show_count = cat_count > 0 and not hide_results
-        if level > 0:
-            header_text = f"--- {level} ---" if not show_count else f"--- {level} ({cat_count}) ---"
-        else:
-            header_text = "--- Unrated ---" if not show_count else f"--- Unrated ({cat_count}) ---"
-        keyboard.append(
-            [InlineKeyboardButton(header_text, callback_data=f"poll_random_vote:{poll_id}:{level}")]
+    # Build + edit within a shrinking size budget. If Telegram still rejects the
+    # keyboard as too long, halve the budget and retry so the poll can never
+    # freeze — it just shows fewer game buttons (dropping lowest complexity
+    # first; those games stay votable via their complexity-category button).
+    budget = _REPLY_MARKUP_BUDGET_BYTES
+    for attempt in range(_RENDER_MAX_ATTEMPTS):
+        keyboard, shown, hidden = _build_poll_keyboard(
+            poll_id,
+            levels_desc,
+            sorted_by_level,
+            vote_counts,
+            priority_ids,
+            category_vote_counts,
+            hide_results,
+            allow_adding,
+            budget,
         )
-
-        # When any game in the group has a long name, render the group at
-        # one button per row so wrapping has more horizontal room. Other
-        # groups stay at two-per-row to keep the keyboard compact.
-        columns = 1 if any(len(g.name) > _BUTTON_LONG_THRESHOLD for g in sorted_group) else 2
-
-        current_row = []
-        for g in sorted_group:
-            count = vote_counts[g.id]
-            prefix = "⭐ " if g.id in priority_ids else ""
-            suffix = f" ({count})" if count > 0 and not hide_results else ""
-            label = _wrap_button_label(prefix, g.name, suffix)
-            current_row.append(InlineKeyboardButton(label, callback_data=f"vote:{poll_id}:{g.id}"))
-
-            if len(current_row) == columns:
-                keyboard.append(current_row)
-                current_row = []
-        if current_row:
-            keyboard.append(current_row)
-
-    # Add action row
-    row_actions = [
-        InlineKeyboardButton("🔄 Refresh", callback_data=f"poll_refresh:{poll_id}"),
-        InlineKeyboardButton("🛑 Close", callback_data=f"poll_close:{poll_id}"),
-    ]
-    if allow_adding:
-        row_actions.insert(1, InlineKeyboardButton("➕ Add", callback_data=f"poll_add:{poll_id}"))
-    keyboard.append(row_actions)
-
-    try:
-        await bot.edit_message_text(
-            chat_id=chat_id,
-            message_id=message_id,
-            text=text,
-            reply_markup=InlineKeyboardMarkup(keyboard),
-            parse_mode="Markdown",
-        )
-    except Exception as e:
-        # Ignore "Message is not modified" errors (common in rapid updates)
-        if "Message is not modified" not in str(e):
+        lines = list(text_lines)
+        if hidden > 0 and not hide_results:
+            lines.insert(
+                3,
+                f"🎛️ _Showing {shown} of {shown + hidden} games as buttons — "
+                f"lower-complexity games are votable via their complexity category._",
+            )
+        text = "\n".join(lines)
+        try:
+            await bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=message_id,
+                text=text,
+                reply_markup=InlineKeyboardMarkup(keyboard),
+                parse_mode="Markdown",
+            )
+            return
+        except Exception as e:
+            msg = str(e)
+            # Ignore "Message is not modified" errors (common in rapid updates).
+            if "Message is not modified" in msg:
+                return
+            if "too long" in msg.lower() and attempt < _RENDER_MAX_ATTEMPTS - 1:
+                budget //= 2  # keyboard still too big — shrink and retry
+                continue
             logger.warning(f"Failed to update poll message: {e}")
+            return
 
 
 # Debounce window for coalescing vote-driven re-renders. A burst of votes within

--- a/tests/test_custom_poll.py
+++ b/tests/test_custom_poll.py
@@ -5,12 +5,16 @@ This tests the alternative poll mechanism that uses inline buttons
 instead of native Telegram polls to overcome the 10-option limit.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy import select
+from telegram import InlineKeyboardMarkup
 
+import src.bot.handlers as handlers
 from src.bot.handlers import (
+    _build_poll_keyboard,
     _render_poll_job,
     _wrap_button_label,
     create_poll,
@@ -2575,3 +2579,150 @@ async def test_render_job_skips_closed_poll(mock_context):
     await _render_poll_job(mock_context)
 
     mock_context.bot.edit_message_text.assert_not_called()
+
+
+# ============================================================================
+# Keyboard Size-Budget Tests (large game lists)
+# ============================================================================
+
+
+def _vote_ids_from_markup(markup):
+    return [
+        int(btn.callback_data.split(":")[2])
+        for row in markup.inline_keyboard
+        for btn in row
+        if btn.callback_data and btn.callback_data.startswith("vote:")
+    ]
+
+
+def _category_levels_from_markup(markup):
+    return [
+        int(btn.callback_data.split(":")[2])
+        for row in markup.inline_keyboard
+        for btn in row
+        if btn.callback_data and btn.callback_data.startswith("poll_random_vote:")
+    ]
+
+
+def test_build_poll_keyboard_drops_lowest_complexity_first():
+    """Within a tight budget, only the highest-complexity games get buttons; the
+    lowest-complexity ones are dropped but keep their category-vote header."""
+    poll_id = "poll_budget"
+    levels_desc = [4, 2]
+    sorted_by_level = {
+        4: [SimpleNamespace(id=i, name=f"G{i}") for i in range(1, 21)],
+        2: [SimpleNamespace(id=i, name=f"G{i}") for i in range(101, 121)],
+    }
+    vote_counts = {g.id: 0 for games in sorted_by_level.values() for g in games}
+
+    keyboard, shown, hidden = _build_poll_keyboard(
+        poll_id, levels_desc, sorted_by_level, vote_counts, set(), {}, False, False, 400
+    )
+
+    markup = InlineKeyboardMarkup(keyboard)
+    vote_ids = _vote_ids_from_markup(markup)
+    assert vote_ids, "at least one high-complexity game should fit"
+    assert all(1 <= i <= 20 for i in vote_ids)  # only level-4 games (ids 1-20)
+    assert shown == len(vote_ids)
+    assert hidden == 40 - shown > 0  # some games were dropped
+    # Both categories keep a header so dropped games stay votable.
+    assert set(_category_levels_from_markup(markup)) == {4, 2}
+
+
+async def _seed_poll_with_levels(chat_id, poll_id, level_counts, message_id=999):
+    """Seed a custom poll whose single player owns games spread across complexity
+    levels. `level_counts` maps complexity float -> count. Game ids are assigned
+    sequentially in the iteration order of `level_counts`."""
+    async with db.AsyncSessionLocal() as session:
+        session.add(Session(chat_id=chat_id, is_active=True, poll_type=PollType.CUSTOM))
+        session.add(User(telegram_id=111, telegram_name="Solo"))
+        await session.flush()
+        gid = 0
+        games = []
+        for complexity, count in level_counts.items():
+            for _ in range(count):
+                gid += 1
+                games.append(
+                    Game(
+                        id=gid,
+                        name=f"Game{gid:03d}",
+                        min_players=1,
+                        max_players=8,
+                        playing_time=60,
+                        complexity=complexity,
+                    )
+                )
+        session.add_all(games)
+        await session.flush()
+        session.add_all([Collection(user_id=111, game_id=g.id) for g in games])
+        session.add(SessionPlayer(session_id=chat_id, user_id=111))
+        session.add(GameNightPoll(poll_id=poll_id, chat_id=chat_id, message_id=message_id))
+        await session.commit()
+        return [g.id for g in games]
+
+
+@pytest.mark.asyncio
+async def test_small_poll_shows_all_games_and_no_note(mock_context):
+    """A poll that fits the budget shows every game and adds no truncation note."""
+    chat_id, poll_id = 12345, "poll_small"
+    ids = await _seed_poll_with_levels(chat_id, poll_id, {2.0: 5})
+
+    async with db.AsyncSessionLocal() as session:
+        games = list((await session.execute(select(Game))).scalars().all())
+        await render_poll_message(mock_context.bot, chat_id, 999, session, poll_id, games, set())
+
+    call = mock_context.bot.edit_message_text.call_args
+    assert "games as buttons" not in call.kwargs["text"]
+    assert sorted(_vote_ids_from_markup(call.kwargs["reply_markup"])) == sorted(ids)
+
+
+@pytest.mark.asyncio
+async def test_large_poll_drops_lowest_complexity_and_notes_it(mock_context, monkeypatch):
+    """Over the budget, the poll keeps high-complexity game buttons, drops the
+    lowest-complexity ones, and tells users where to find them."""
+    monkeypatch.setattr(handlers, "_REPLY_MARKUP_BUDGET_BYTES", 500)
+    chat_id, poll_id = 12345, "poll_big"
+    # ids 1-10 = complexity 4 (high), ids 11-20 = complexity 2 (low).
+    await _seed_poll_with_levels(chat_id, poll_id, {4.0: 10, 2.0: 10})
+
+    async with db.AsyncSessionLocal() as session:
+        games = list((await session.execute(select(Game))).scalars().all())
+        await render_poll_message(mock_context.bot, chat_id, 999, session, poll_id, games, set())
+
+    call = mock_context.bot.edit_message_text.call_args
+    markup = call.kwargs["reply_markup"]
+    vote_ids = _vote_ids_from_markup(markup)
+    assert vote_ids and all(1 <= i <= 10 for i in vote_ids)  # only high-complexity shown
+    assert len(vote_ids) < 20  # some dropped
+    assert "games as buttons" in call.kwargs["text"]
+    # Both complexity categories keep a header (low-complexity games votable there).
+    assert set(_category_levels_from_markup(markup)) == {4, 2}
+
+
+@pytest.mark.asyncio
+async def test_render_retries_when_reply_markup_too_long(mock_context):
+    """If Telegram still rejects the keyboard as too long, the render retries
+    (with a smaller budget) instead of silently freezing the poll."""
+    chat_id, poll_id = 12345, "poll_retry"
+    await _seed_poll_with_levels(chat_id, poll_id, {3.0: 12})
+
+    calls = []
+
+    async def fake_edit(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise Exception("Bad Request: reply markup is too long")
+
+    mock_context.bot.edit_message_text = AsyncMock(side_effect=fake_edit)
+
+    async with db.AsyncSessionLocal() as session:
+        games = list((await session.execute(select(Game))).scalars().all())
+        await render_poll_message(mock_context.bot, chat_id, 999, session, poll_id, games, set())
+
+    assert len(calls) == 2  # first failed, retried once
+
+    def n_votes(kwargs):
+        return len(_vote_ids_from_markup(kwargs["reply_markup"]))
+
+    # Retry shrinks the budget, so it never shows more buttons than the failed try.
+    assert n_votes(calls[1]) <= n_votes(calls[0])


### PR DESCRIPTION
## Problem

Large game lists overflow Telegram's `reply_markup` size limit. The edit fails with `Reply markup is too long`, the error is swallowed, and because the oversized keyboard recurs on every render the poll freezes (confirmed in prod logs). The pagination attempt (#90) fixed the size but broke multi-user use — a custom poll is a **single shared message**, so one user's page change switched the keyboard for everyone (reverted in #92).

## Fix — bound the single shared keyboard's size

No view-state, so nothing differs between users:

- Always render every complexity-**category header** (keeps every category votable) and the action row.
- Add individual game buttons **highest-complexity-first** until the next would exceed a serialized **byte budget** — so the games left without a button are the **lowest-complexity** ones (per request). They stay votable via their complexity-category button.
- When games are hidden, add a note to the message text: `Showing X of Y games as buttons — lower-complexity games are votable via their complexity category.`
- **Self-correcting safety net:** if Telegram still rejects the keyboard as too long, halve the budget and re-render (up to a few attempts). The exact server limit is undocumented, so this guarantees it can never freeze again rather than relying on a hard-coded number.

## Tests

- `_build_poll_keyboard` keeps only high-complexity games under a tight budget, drops the rest, keeps all category headers.
- Small poll → all games, no note.
- Large poll → only high-complexity buttons + truncation note + both category headers.
- A `reply markup is too long` failure triggers a retry with a smaller budget (no freeze).
- Full suite: 192 passed. lint/format/mypy clean.

## Notes

- No migration. The unused `current_page` column from the reverted #90 is left in place (already applied in prod; removing its migration file would break `alembic upgrade head`). Can be dropped in a follow-up if desired.
- Trade-off (confirmed): on very large collections the lowest-complexity games won't have individual buttons, only category voting.