### PR TITLE
perf(deploy): keep CPU allocated after webhook response on Cloud Run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,11 +121,12 @@ jobs:
           flags: |
             --cpu=1
             --memory=512Mi
-            --min-instances=0
+            --min-instances=1
             --max-instances=3
             --concurrency=40
             --timeout=30s
             --cpu-boost
+            --no-cpu-throttling
             --allow-unauthenticated
 
       - name: Smoke test


### PR DESCRIPTION
## Problem

Every UI action (joining a game night, starting a poll, voting) is slow — warm *and* cold.

Root cause is the PTB-webhook-on-Cloud-Run footgun: `run_webhook` queues each update and returns HTTP **200 immediately**, so the actual handler, its DB round-trips, and the debounced poll-render job (`job_queue.run_once`) all execute **after** the response is sent. Cloud Run's default only allocates CPU while a request is in flight (`--cpu-boost` only helps the cold-start window), so all that post-response work ran at a throttled fraction of a vCPU. The unavoidable cross-region Cloud Run↔Neon round-trips (free-tier constraint) then ran at throttled CPU too, compounding the lag.

## Change

| Flag | Why |
|---|---|
| `--no-cpu-throttling` | Allocate CPU for the whole instance lifetime so detached handler/job work runs at full speed. This is the core fix. |
| `--min-instances=0` → `1` | Avoid cold starts on a mostly-idle bot. |

`--cpu-boost` retained for faster warm-instance startup on deploys.

## Cost note

`--no-cpu-throttling` switches the instance to billing for its full lifetime, and `--min-instances=1` keeps one instance always on. For a single low-traffic bot this is a small, predictable cost. If it's unwelcome, drop `--min-instances` back to `0` (keeps the core throttling fix; trades it for occasional cold starts).

## Verification

After merge + deploy, time a vote/join end-to-end and check Cloud Run logs for the gap between "200 returned" and handler completion — it should collapse.